### PR TITLE
Add UseTrusted parameter to the Xslt Task

### DIFF
--- a/Source/MSBuild.Community.Tasks/Xslt/Xslt.cs
+++ b/Source/MSBuild.Community.Tasks/Xslt/Xslt.cs
@@ -1,6 +1,6 @@
 //-----------------------------------------------------------------------
 // <copyright file="Xslt.cs" company="MSBuild Community Tasks Project">
-//     Copyright © 2006 Ignaz Kohlbecker
+//     Copyright ï¿½ 2006 Ignaz Kohlbecker
 // </copyright>
 //-----------------------------------------------------------------------
 
@@ -43,6 +43,7 @@ namespace MSBuild.Community.Tasks
 		private ITaskItem[] inputs;
 		private string rootTag;
 		private string rootAttributes;
+		private bool useTrusted;
 		private ITaskItem xsl;
 		private string output;
 		#endregion Fields
@@ -100,6 +101,23 @@ namespace MSBuild.Community.Tasks
 			set
 			{
 				this.rootAttributes = value;
+			}
+		}
+		
+		/// <summary>
+		/// Enables a Trusted XSLT processor. Sepcifically enables scripts 
+		/// in the xsl transformation file
+		/// For example: <code>UseTrusted="true"</code>
+		/// </summary>
+		public bool UseTrusted
+		{
+			get
+			{
+				return useTrusted;
+			}
+			set
+			{
+				useTrusted = value;
 			}
 		}
 
@@ -242,7 +260,12 @@ namespace MSBuild.Community.Tasks
 
 			try
 			{
-				transform.Load(this.xsl.ItemSpec);
+				transform.Load(
+						xsl.ItemSpec, 
+						useTrusted
+							? XsltSettings.TrustedXslt
+							: XsltSettings.Default,
+						null);
 				xmlWriter = XmlWriter.Create(this.output, transform.OutputSettings);
 
 				transform.Transform(doc.DocumentElement, argumentList, xmlWriter);


### PR DESCRIPTION
This enables using a trusted Xslt Processor. Specifically allows scripting in the xslt files.
