### PR TITLE
Restore StandardErrorLoggingImportance pre-3.5 value

### DIFF
--- a/Source/MSBuild.Community.Tasks/Git/GitClient.cs
+++ b/Source/MSBuild.Community.Tasks/Git/GitClient.cs
@@ -147,6 +147,16 @@ namespace MSBuild.Community.Tasks.Git
         }
 
         /// <summary>
+        /// Gets the <see cref="T:Microsoft.Build.Framework.MessageImportance"></see> with which to log errors.
+        /// </summary>
+        /// <value></value>
+        /// <returns>The <see cref="T:Microsoft.Build.Framework.MessageImportance"></see> with which to log errors.</returns>
+        protected override MessageImportance StandardErrorLoggingImportance
+        {
+            get { return MessageImportance.High; }
+        }
+
+        /// <summary>
         /// Gets the name of the executable file to run.
         /// </summary>
         /// <returns>

--- a/Source/MSBuild.Community.Tasks/Sandcastle/SandcastleToolBase.cs
+++ b/Source/MSBuild.Community.Tasks/Sandcastle/SandcastleToolBase.cs
@@ -151,6 +151,16 @@ namespace MSBuild.Community.Tasks.Sandcastle
         }
 
         /// <summary>
+        /// Gets the <see cref="T:Microsoft.Build.Framework.MessageImportance"></see> with which to log errors.
+        /// </summary>
+        /// <value></value>
+        /// <returns>The <see cref="T:Microsoft.Build.Framework.MessageImportance"></see> with which to log errors.</returns>
+        protected override MessageImportance StandardErrorLoggingImportance
+        {
+            get { return MessageImportance.High; }
+        }
+
+        /// <summary>
         /// Gets the override value of the PATH environment variable.
         /// </summary>
         /// <value></value>

--- a/Source/MSBuild.Community.Tasks/Subversion/SvnClient.cs
+++ b/Source/MSBuild.Community.Tasks/Subversion/SvnClient.cs
@@ -505,6 +505,16 @@ namespace MSBuild.Community.Tasks.Subversion
         }
 
         /// <summary>
+        /// Gets the <see cref="T:Microsoft.Build.Framework.MessageImportance"></see> with which to log errors.
+        /// </summary>
+        /// <value></value>
+        /// <returns>The <see cref="T:Microsoft.Build.Framework.MessageImportance"></see> with which to log errors.</returns>
+        protected override MessageImportance StandardErrorLoggingImportance
+        {
+            get { return MessageImportance.High; }
+        }
+
+        /// <summary>
         /// Gets the name of the executable file to run.
         /// </summary>
         /// <value></value>

--- a/Source/MSBuild.Community.Tasks/Tfs/TfsClient.cs
+++ b/Source/MSBuild.Community.Tasks/Tfs/TfsClient.cs
@@ -321,6 +321,16 @@ namespace MSBuild.Community.Tasks.Tfs
         }
 
         /// <summary>
+        /// Gets the <see cref="T:Microsoft.Build.Framework.MessageImportance"></see> with which to log errors.
+        /// </summary>
+        /// <value></value>
+        /// <returns>The <see cref="T:Microsoft.Build.Framework.MessageImportance"></see> with which to log errors.</returns>
+        protected override MessageImportance StandardErrorLoggingImportance
+        {
+            get { return MessageImportance.High; }
+        }
+
+        /// <summary>
         /// Gets the name of the executable file to run.
         /// </summary>
         /// <returns>


### PR DESCRIPTION
The default value for the StandardErrorLoggingImportance property on the
Microsoft.Build.Utilities.ToolTask class changed from High in .net 2.0
to Normal in 3.5 and up.

When the MSBuild.Community.Tasks project was migrated to 3.5 in pull
request #25 to fix the problem mentioned in issue #19, the change to
StandardErrorLoggingImportance was not accounted for, and several tasks
that depended on this to distinguish errors from regular messages in their
LogEventsFromTextOutput() methods stopped working correctly.

This commit adds StandardErrorLoggingImportance overrides to the
impacted tasks, restoring the pre-3.5 value of High for error messages.

[fixes #31]
[fixes #34]
