### PR TITLE
Add support for nuget pack -Verbosity and -Properties switches

### DIFF
--- a/Source/MSBuild.Community.Tasks/NuGet/NuGetPack.cs
+++ b/Source/MSBuild.Community.Tasks/NuGet/NuGetPack.cs
@@ -85,6 +85,11 @@ namespace MSBuild.Community.Tasks.NuGet
         public bool Symbols { get; set; }
 
         /// <summary>
+        /// Provides the ability to specify a semicolon ";" delimited list of properties when creating a package.
+        /// </summary>
+        public string Properties { get; set; }
+
+        /// <summary>
         /// Returns a string value containing the command line arguments to pass directly to the executable file.
         /// </summary>
         /// <returns>
@@ -106,6 +111,7 @@ namespace MSBuild.Community.Tasks.NuGet
 
             if (Symbols)
                 builder.AppendSwitch("-Symbols");
+            builder.AppendSwitchIfNotNull("-Properties ", Properties);
 
             return builder.ToString();
         }


### PR DESCRIPTION
As of NuGet 2.0, the NuGet.exe Pack command-line supports a few new switches and some are deprecated.  I'm adding support for the Verbosity (which replaced Verbose) and Properties switches.  Properties is especially handy for specifying a build configuration.

The **MSBuild.Community.Tasks.Tests** project didn't have tests for the `MSBuild.Community.Tasks.Nuget` namespace, so my changes didn't involve any tests either.  With more time, perhaps I could add some tests.  However, these changes were manually tested against another project of mine.
