### PR TITLE
Minimal Logging in Zip.cs

### DIFF
--- a/Source/MSBuild.Community.Tasks/Zip.cs
+++ b/Source/MSBuild.Community.Tasks/Zip.cs
@@ -238,10 +238,7 @@ namespace MSBuild.Community.Tasks
                             if (Directory.Exists(name))
                             {
                                 var directoryEntry = zip.AddDirectory(name, directoryPathInArchive);
-                                if (!MinimalLogging)
-                                {
-                                    Log.LogMessage(Resources.ZipAdded, directoryEntry.FileName);
-                                }
+                                LogMessageIfNotMinimalLogging(Resources.ZipAdded, directoryEntry.FileName);
 
                                 continue;
                             }
@@ -257,10 +254,7 @@ namespace MSBuild.Community.Tasks
 
                         var entry = zip.AddFile(name, directoryPathInArchive);
 
-                        if (!MinimalLogging)
-                        {
-                            Log.LogMessage(Resources.ZipAdded, entry.FileName);
-                        }
+                        LogMessageIfNotMinimalLogging(Resources.ZipAdded, entry.FileName);
                     }
 
                     zip.Save(ZipFileName);
@@ -303,6 +297,14 @@ namespace MSBuild.Community.Tasks
                 relativePath.Add(originalDirectories[x]);
 
             return string.Join(Path.DirectorySeparatorChar.ToString(), relativePath.ToArray());
+        }
+
+        private void LogMessageIfNotMinimalLogging(string message, params object[] messageArguments)
+        {
+            if (!MinimalLogging)
+            {
+                Log.LogMessage(message, messageArguments);
+            }
         }
 
         #endregion Private Methods


### PR DESCRIPTION
Hi,

I extended the Zip class with a MinimalLogging property. I was using this class to make a Zip I could use for installation. The logging produced by this class cluttered my cmd window.

When this property is enabled the only thing that will be logged is Creating and Created messages, warnings and errors.
