### PR TITLE
in NuGetPack, added output param of file path for the newly created package

### DIFF
--- a/Source/MSBuild.Community.Tasks/NuGet/NuGetBase.cs
+++ b/Source/MSBuild.Community.Tasks/NuGet/NuGetBase.cs
@@ -32,6 +32,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using Microsoft.Build.Utilities;
+using Microsoft.Build.Framework;
 
 
 
@@ -73,6 +74,26 @@ namespace MSBuild.Community.Tasks.NuGet
         protected override string ToolName
         {
             get { return "NuGet.exe"; }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="T:Microsoft.Build.Framework.MessageImportance"></see> with which to log output.
+        /// </summary>
+        /// <value></value>
+        /// <returns>The <see cref="T:Microsoft.Build.Framework.MessageImportance"></see> with which to log output.</returns>
+        protected override MessageImportance StandardOutputLoggingImportance
+        {
+            get { return MessageImportance.Normal; }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="T:Microsoft.Build.Framework.MessageImportance"></see> with which to log errors.
+        /// </summary>
+        /// <value></value>
+        /// <returns>The <see cref="T:Microsoft.Build.Framework.MessageImportance"></see> with which to log errors.</returns>
+        protected override MessageImportance StandardErrorLoggingImportance
+        {
+            get { return MessageImportance.High; }
         }
 
         /// <summary>


### PR DESCRIPTION
I've often found it tedious to determine the name of the NuGet Package created by NuGetPack.  To help with this, I've added a new output parameter to NuGetPack that provides the name of the newly created NuGet Package.
