### PR TITLE
Added missing GitBranch UsingTask declaration to .Targets file

### DIFF
--- a/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Targets
+++ b/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Targets
@@ -134,6 +134,7 @@
 
   <UsingTask AssemblyFile="$(MSBuildCommunityTasksLib)" TaskName="MSBuild.Community.Tasks.Git.GitClient" />
   <UsingTask AssemblyFile="$(MSBuildCommunityTasksLib)" TaskName="MSBuild.Community.Tasks.Git.GitVersion" />
+  <UsingTask AssemblyFile="$(MSBuildCommunityTasksLib)" TaskName="MSBuild.Community.Tasks.Git.GitBranch" />
 
   <ItemGroup>
     <FxCopRuleAssemblies Include="UsageRules.dll"/>


### PR DESCRIPTION
In the last update the GitBranch task was added, but it is missing from the .Targets file.
This fixes the missing declaration.
