### PR TITLE
Added BuildTree to SvnCopy

### DIFF
--- a/Source/MSBuild.Community.Tasks.Tests/Subversion/SvnCopyTest.cs
+++ b/Source/MSBuild.Community.Tasks.Tests/Subversion/SvnCopyTest.cs
@@ -20,5 +20,18 @@ namespace MSBuild.Community.Tasks.Tests.Subversion
             string actualCommand = TaskUtility.GetToolTaskCommand(task);
             Assert.AreEqual(expectedCommand, actualCommand);
         }
+
+        [Test]
+        public void SvnCopyBuildTreeExecute()
+        {
+            SvnCopy task = new SvnCopy();
+            task.Message = "Tagging";
+            task.SourcePath = "file:///d:/svn/trunk/path";
+            task.DestinationPath = "file:///d:/svn/tags/release/path";
+            task.BuildTree = true;
+            string expectedCommand = "copy \"file:///d:/svn/trunk/path\" \"file:///d:/svn/tags/release/path\" --parents --message \"Tagging\" --non-interactive --no-auth-cache";
+            string actualCommand = TaskUtility.GetToolTaskCommand(task);
+            Assert.AreEqual(expectedCommand, actualCommand);
+        }
     }
 }

--- a/Source/MSBuild.Community.Tasks/Subversion/SvnCopy.cs
+++ b/Source/MSBuild.Community.Tasks/Subversion/SvnCopy.cs
@@ -99,7 +99,7 @@ namespace MSBuild.Community.Tasks.Subversion
         /// <returns></returns>
         protected override string GenerateSvnCommand()
         {
-            return String.Format("{0} {1} \"{2}\" \"{3}\"", base.GenerateSvnCommand(), BuildTree ? "--parents" : "", sourcePath, destinationPath);
+            return String.Format("{0} \"{2}\" \"{3}\"{1}", base.GenerateSvnCommand(), BuildTree ? " --parents" : "", sourcePath, destinationPath);
         }
 
         /// <summary>


### PR DESCRIPTION
Implemented feature request for issue #59.  Added BuildTree property to SvnCopy to expose the svn copy --parents switch.  This switch builds any missing directories and sub-directories in the Destination Path.
