### PR TITLE
Removed duplicate using directive for 'System'

### DIFF
--- a/Source/MSBuild.Community.Tasks/TemplateFile/TemplateFile.cs
+++ b/Source/MSBuild.Community.Tasks/TemplateFile/TemplateFile.cs
@@ -1,4 +1,3 @@
- using System;
 using System;
 using System.Collections.Generic;
 using System.IO;


### PR DESCRIPTION
Implemented fix for issue #61.  Removed the duplicate using directive for 'System' in TemplateFile/TemplateFile.cs.  This was causing a compiler warning.
