### PR TITLE
Support parenthesis in MSBuildCommunityTasksPath

### DIFF
--- a/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Targets
+++ b/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Targets
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == ''">$(MSBuildExtensionsPath)\MSBuildCommunityTasks</MSBuildCommunityTasksPath>
-    <MSBuildCommunityTasksLib>$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.dll</MSBuildCommunityTasksLib>
+    <MSBuildCommunityTasksLib>$([MSBUILD]::Unescape($(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.dll))</MSBuildCommunityTasksLib>
   </PropertyGroup>
 
   <UsingTask AssemblyFile="$(MSBuildCommunityTasksLib)" TaskName="MSBuild.Community.Tasks.AspNet.InstallAspNet" />


### PR DESCRIPTION
Fix for Issue #63. MsBuild has a known issue where parenthesis in file paths cause UsingTask to insert %28 and %29 instead of parenthesis.
