### PR TITLE
TemplateFile task does not recognize dots or dashes as part of tokens

### DIFF
--- a/Source/MSBuild.Community.Tasks.Tests/TemplateFile/TemplateFileTest.cs
+++ b/Source/MSBuild.Community.Tasks.Tests/TemplateFile/TemplateFileTest.cs
@@ -16,10 +16,12 @@ namespace MSBuild.Community.Tasks.Tests
 			{Non-TemplateItem} = NonTemplateItem
 			${item2}
 			${CASEInsenSiTiveTest}
+            ${Template.Item.With.Dot}
 		";
 		private static string _templateReplaced =
-			_template.Replace("${TemplateItem}", "**Item1**").Replace("${item2}", "**Item2**").Replace("${CASEInsenSiTiveTest}",
-				"**Item3**");
+			_template.Replace("${TemplateItem}", "**Item1**").Replace("${item2}", "**Item2**")
+                .Replace("${CASEInsenSiTiveTest}", "**Item3**")
+                .Replace("${Template.Item.With.Dot}", "**Item4**");
 		private static string _templateFilename;
 		private string _replacedFilename;
 
@@ -72,6 +74,9 @@ namespace MSBuild.Community.Tasks.Tests
 			item = new TaskItem("caseInsensitiveTest");
 			SetMetaData(item, "**Item3**", includeMetaData);
 			result.Add(item);
+            item = new TaskItem("Template.Item.With.Dot");
+            SetMetaData(item, "**Item4**", includeMetaData);
+            result.Add(item);
 			return result.ToArray();
 		}
 
@@ -150,7 +155,8 @@ namespace MSBuild.Community.Tasks.Tests
 			Assert.AreEqual(Path.ChangeExtension(_templateFilename, ".out"), _replacedFilename);
 			string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
 			string shouldBeReplaced =
-				_template.Replace("${TemplateItem}", "").Replace("${item2}", "").Replace("${CASEInsenSiTiveTest}", "");
+				_template.Replace("${TemplateItem}", "").Replace("${item2}", "").Replace("${CASEInsenSiTiveTest}", "")
+                    .Replace("${Template.Item.With.Dot}", "");
 			Assert.AreEqual(shouldBeReplaced, replaced);
 		}
 

--- a/Source/MSBuild.Community.Tasks/TemplateFile/TemplateFile.cs
+++ b/Source/MSBuild.Community.Tasks/TemplateFile/TemplateFile.cs
@@ -42,7 +42,7 @@ namespace MSBuild.Community.Tasks
 		/// </summary>
 		public TemplateFile()
 		{
-			_regex = new Regex(@"(?<token>\$\{(?<identifier>\w*)\})", RegexOptions.Singleline | RegexOptions.Compiled 
+			_regex = new Regex(@"(?<token>\$\{(?<identifier>[^}]*)\})", RegexOptions.Singleline | RegexOptions.Compiled 
 				| RegexOptions.Multiline | RegexOptions.IgnoreCase);
 		}
 


### PR DESCRIPTION
I can define TaskItems with ItemSpec property set to "Template.Item.With.Dots", but the TemplateFile does not replace the tokens "${Template.Item.With.Dots}" with the replacement value. This change allows token names containing any character (except }).
