### PR TITLE
Added support for git status branch without #

### DIFF
--- a/Source/MSBuild.Community.Tasks.Tests/Git/GitBranchTest.cs
+++ b/Source/MSBuild.Community.Tasks.Tests/Git/GitBranchTest.cs
@@ -16,6 +16,9 @@ namespace MSBuild.Community.Tasks.Tests.Git
 			string statusLine = "# On branch 0.1.0";
 			GitBranch gitBranch = new GitBranch();
 			Assert.AreEqual("0.1.0", gitBranch.ParseStatusLineOutput(statusLine));
+
+			statusLine = "On branch 0.1.0";
+			Assert.AreEqual("0.1.0", gitBranch.ParseStatusLineOutput(statusLine));
 		}
 
 		[Test]
@@ -24,6 +27,9 @@ namespace MSBuild.Community.Tasks.Tests.Git
 			string statusLine = "# On branch 0.1  ";
 			GitBranch gitBranch = new GitBranch();
 			Assert.AreEqual("0.1", gitBranch.ParseStatusLineOutput(statusLine));
+
+			statusLine = "On branch 0.1  ";
+			Assert.AreEqual("0.1", gitBranch.ParseStatusLineOutput(statusLine));
 		}
 
 		[Test]
@@ -31,6 +37,9 @@ namespace MSBuild.Community.Tasks.Tests.Git
 		{
 			string statusLine = "# On branch master    ";
 			GitBranch gitBranch = new GitBranch();
+			Assert.AreEqual("master", gitBranch.ParseStatusLineOutput(statusLine));
+
+			statusLine = "On branch master    ";
 			Assert.AreEqual("master", gitBranch.ParseStatusLineOutput(statusLine));
 		}
 
@@ -49,6 +58,19 @@ namespace MSBuild.Community.Tasks.Tests.Git
 			Assert.IsFalse(gitBranch.IsBranchStatusLine("#   (use \"git add <file>...\" to include in what will be committed)"));
 			Assert.IsFalse(gitBranch.IsBranchStatusLine("#"));
 			Assert.IsFalse(gitBranch.IsBranchStatusLine("#       build/git.bat"));
+			Assert.IsFalse(gitBranch.IsBranchStatusLine("no changes added to commit (use \"git add\" and/or \"git commit -a\")"));
+
+			Assert.IsTrue(gitBranch.IsBranchStatusLine("On branch 0.1"));
+			Assert.IsFalse(gitBranch.IsBranchStatusLine("Changes not staged for commit:"));
+			Assert.IsFalse(gitBranch.IsBranchStatusLine("  (use \"git add <file>...\" to update what will be committed)"));
+			Assert.IsFalse(gitBranch.IsBranchStatusLine("  (use \"git checkout -- <file>...\" to discard changes in working directory)"));
+			Assert.IsFalse(gitBranch.IsBranchStatusLine(""));
+			Assert.IsFalse(gitBranch.IsBranchStatusLine("      modified:   build/MSBuildCodeMetrics.build"));
+			Assert.IsFalse(gitBranch.IsBranchStatusLine(""));
+			Assert.IsFalse(gitBranch.IsBranchStatusLine("Untracked files:"));
+			Assert.IsFalse(gitBranch.IsBranchStatusLine("  (use \"git add <file>...\" to include in what will be committed)"));
+			Assert.IsFalse(gitBranch.IsBranchStatusLine(""));
+			Assert.IsFalse(gitBranch.IsBranchStatusLine("      build/git.bat"));
 			Assert.IsFalse(gitBranch.IsBranchStatusLine("no changes added to commit (use \"git add\" and/or \"git commit -a\")"));
 		}
 	}

--- a/Source/MSBuild.Community.Tasks/Git/GitBranch.cs
+++ b/Source/MSBuild.Community.Tasks/Git/GitBranch.cs
@@ -55,7 +55,7 @@ namespace MSBuild.Community.Tasks.Git
 		/// <returns>true if is branch line</returns>
 		public bool IsBranchStatusLine(string singleLine)
 		{
-			return singleLine.StartsWith("# On");
+			return singleLine.StartsWith("# On branch") || singleLine.StartsWith("On branch");
 		}
 
 		/// <summary>


### PR DESCRIPTION
Msysgit 1.8.5.2-preview20131230 does not print # chars when running "git
status branch" this broke the GitBranch task, this change fixes that.
