### PR TITLE
Fixed broken example of TemplateFile usage

### DIFF
--- a/Source/MSBuild.Community.Tasks/TemplateFile/TemplateFile.cs
+++ b/Source/MSBuild.Community.Tasks/TemplateFile/TemplateFile.cs
@@ -18,7 +18,7 @@ namespace MSBuild.Community.Tasks
 	///		</Tokens>
 	/// </ItemGroup>
 	/// 
-	/// <TemplateFile TemplateFile="ATemplateFile.template" OutputFile="ReplacedFile.txt" Tokens="@(Tokens)" />
+    /// <TemplateFile Template="ATemplateFile.template" OutputFilename="ReplacedFile.txt" Tokens="@(Tokens)" />
 	/// ]]></code>
 	/// </example>
 	/// <remarks>Tokens in the template file are formatted using ${var} syntax and names are not 


### PR DESCRIPTION
TemplateFile class comment has broken usage example.
TemplateFile attribute doesn't exists and OutputFile is not used anywhere in code.
