### PR TITLE
Fixes comment bug in ILMerge test.

### DIFF
--- a/Source/MSBuild.Community.Tasks.Tests/ILMerge/ILMergeTest.cs
+++ b/Source/MSBuild.Community.Tasks.Tests/ILMerge/ILMergeTest.cs
@@ -15,7 +15,7 @@ namespace MSBuild.Community.Tasks.Tests
 	using Microsoft.Build.Utilities;
 
 	/// <summary>
-	/// NUnit tests for the MSBuild <see cref="Microsoft.Build.Framework.Task"/> 
+	/// NUnit tests for the MSBuild <see cref="Microsoft.Build.Framework.ITask"/> 
 	/// <see cref="ILMerge"/>.
 	/// </summary>
 	[TestFixture]


### PR DESCRIPTION
This causes build warnings under some builds. The type referenced doesn't exist. It's missing an "I".
