### PR TITLE
Moves FxCop rules out of publicly shipping .targets file...

### DIFF
--- a/Master-helper.proj
+++ b/Master-helper.proj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="Build\MSBuild.Community.Tasks.Targets" />
+  <Import Project="Build\MSBuild.Community.Tasks.Internal.targets" />
 
   <PropertyGroup>
     <Major>1</Major>

--- a/Source/FxCop.proj
+++ b/Source/FxCop.proj
@@ -6,7 +6,7 @@
 		<MSBuildCommunityTasksPath>$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\bin\Debug</MSBuildCommunityTasksPath>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\MSBuild.Community.Tasks.Targets"/>
+	<Import Project="$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\MSBuild.Community.Tasks.Internal.targets"/>
 
 	<Target Name="DoFxCop">
 

--- a/Source/InnoSetup.proj
+++ b/Source/InnoSetup.proj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="All"  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Required Import to use MSBuild Community Tasks -->
-  <Import Project="$(MSBuildExtensionsPath)\MSBuildCommunityTasks\MSBuild.Community.Tasks.Targets"/>
+  <Import Project="$(MSBuildExtensionsPath)\MSBuildCommunityTasks\MSBuild.Community.Tasks.Internal.targets"/>
   
   <!-- These are sample targets the demonstrate the use of MSBuild Community Tasks  -->
   <Target Name="InnoSetup">

--- a/Source/MSBuild.Community.Tasks.Tests/AspNet/AspNetTest.proj
+++ b/Source/MSBuild.Community.Tasks.Tests/AspNet/AspNetTest.proj
@@ -12,7 +12,7 @@
     <MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == ''">$(MSBuildExtensionsPath)/MSBuildCommunityTasks</MSBuildCommunityTasksPath>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Targets" />
+  <Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Internal.targets" />
 
   <PropertyGroup>
     <TestWebPath>$(testdir)\web</TestWebPath>

--- a/Source/MSBuild.Community.Tasks.Tests/Computer/ComputerTest.proj
+++ b/Source/MSBuild.Community.Tasks.Tests/Computer/ComputerTest.proj
@@ -11,7 +11,7 @@
     <MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == ''">$(MSBuildExtensionsPath)/MSBuildCommunityTasks</MSBuildCommunityTasksPath>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildCommunityTasksPath)/MSBuild.Community.Tasks.Targets" />
+  <Import Project="$(MSBuildCommunityTasksPath)/MSBuild.Community.Tasks.Internal.targets" />
 
   <Target Name="Test">
     <Computer>

--- a/Source/MSBuild.Community.Tasks.Tests/IIS/IISTest.proj
+++ b/Source/MSBuild.Community.Tasks.Tests/IIS/IISTest.proj
@@ -12,7 +12,7 @@
 		<MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == ''">$(MSBuildExtensionsPath)/MSBuildCommunityTasks</MSBuildCommunityTasksPath>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Targets" />
+	<Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Internal.targets" />
 
 	<Target Name="buildinfo">
 		<Message Text="MSBuildProjectFullPath: $(MSBuildProjectFullPath)" />

--- a/Source/MSBuild.Community.Tasks.Tests/ILMerge/ILMergeTest.proj
+++ b/Source/MSBuild.Community.Tasks.Tests/ILMerge/ILMergeTest.proj
@@ -26,7 +26,7 @@
 		<allowDuplicates Include="ClassAB" />
 	</ItemGroup>
 
-	<Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Targets" />
+	<Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Internal.targets" />
 
 	<Target Name="buildinfo">
 		<Message Text="MSBuildProjectFullPath: $(MSBuildProjectFullPath)" />

--- a/Source/MSBuild.Community.Tasks.Tests/Install/InstallTest.proj
+++ b/Source/MSBuild.Community.Tasks.Tests/Install/InstallTest.proj
@@ -8,7 +8,7 @@
 	<PropertyGroup>
 		<MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == ''">$(MSBuildExtensionsPath)/MSBuildCommunityTasks</MSBuildCommunityTasksPath>
 	</PropertyGroup>
-	<Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Targets" />
+	<Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Internal.targets" />
 
 	<Target Name="buildinfo">
 		<Message Text="MSBuildProjectFullPath: $(MSBuildProjectFullPath)" />

--- a/Source/MSBuild.Community.Tasks.Tests/JavaScript/JavaScriptTest.proj
+++ b/Source/MSBuild.Community.Tasks.Tests/JavaScript/JavaScriptTest.proj
@@ -11,7 +11,7 @@
 		<MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == ''">$(MSBuildExtensionsPath)/MSBuildCommunityTasks</MSBuildCommunityTasksPath>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildCommunityTasksPath)/MSBuild.Community.Tasks.Targets" />
+	<Import Project="$(MSBuildCommunityTasksPath)/MSBuild.Community.Tasks.Internal.targets" />
 
 	<Target Name="buildinfo">
 		<Message Text="MSBuildProjectFullPath: $(MSBuildProjectFullPath)" />

--- a/Source/MSBuild.Community.Tasks.Tests/Regex/RegexTest.proj
+++ b/Source/MSBuild.Community.Tasks.Tests/Regex/RegexTest.proj
@@ -11,7 +11,7 @@
     <MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == ''">$(MSBuildExtensionsPath)/MSBuildCommunityTasks</MSBuildCommunityTasksPath>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildCommunityTasksPath)/MSBuild.Community.Tasks.Targets" />
+  <Import Project="$(MSBuildCommunityTasksPath)/MSBuild.Community.Tasks.Internal.targets" />
   
   <ItemGroup>
     <TestGroup Include="foo.my.foo.foo.test.o" />

--- a/Source/MSBuild.Community.Tasks.Tests/Solution/GetSolutionProjectsTest.proj
+++ b/Source/MSBuild.Community.Tasks.Tests/Solution/GetSolutionProjectsTest.proj
@@ -11,7 +11,7 @@
     <MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == ''">$(MSBuildExtensionsPath)/MSBuildCommunityTasks</MSBuildCommunityTasksPath>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildCommunityTasksPath)/MSBuild.Community.Tasks.Targets" />
+  <Import Project="$(MSBuildCommunityTasksPath)/MSBuild.Community.Tasks.Internal.targets" />
 
   <PropertyGroup>
     <TargetSolution>TestSolution.sln</TargetSolution>

--- a/Source/MSBuild.Community.Tasks.Tests/SqlServer/SqlServer.proj
+++ b/Source/MSBuild.Community.Tasks.Tests/SqlServer/SqlServer.proj
@@ -8,7 +8,7 @@
 		<MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == ''">$(MSBuildExtensionsPath)\MSBuildCommunityTasks</MSBuildCommunityTasksPath>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Targets" />
+	<Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Internal.targets" />
 
 	<PropertyGroup>
 		<ConnectionString>Server=localhost;Integrated Security=True</ConnectionString>

--- a/Source/MSBuild.Community.Tasks.Tests/TemplateFile/TemplateFile.proj
+++ b/Source/MSBuild.Community.Tasks.Tests/TemplateFile/TemplateFile.proj
@@ -8,7 +8,7 @@
 		<MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == ''">$(MSBuildExtensionsPath)/MSBuildCommunityTasks</MSBuildCommunityTasksPath>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Targets" />
+	<Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Internal.targets" />
 
 	<ItemGroup>
 		<Tokens Include="Name">

--- a/Source/MSBuild.Community.Tasks.Tests/Time/TimeTest.proj
+++ b/Source/MSBuild.Community.Tasks.Tests/Time/TimeTest.proj
@@ -11,7 +11,7 @@
 		<MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == ''">$(MSBuildExtensionsPath)/MSBuildCommunityTasks</MSBuildCommunityTasksPath>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildCommunityTasksPath)/MSBuild.Community.Tasks.Targets" />
+	<Import Project="$(MSBuildCommunityTasksPath)/MSBuild.Community.Tasks.Internal.targets" />
 
 	<Target Name="buildinfo">
 		<Message Text="MSBuildProjectFullPath: $(MSBuildProjectFullPath)" />

--- a/Source/MSBuild.Community.Tasks.Tests/User/UserTest.proj
+++ b/Source/MSBuild.Community.Tasks.Tests/User/UserTest.proj
@@ -11,7 +11,7 @@
     <MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == ''">$(MSBuildExtensionsPath)/MSBuildCommunityTasks</MSBuildCommunityTasksPath>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildCommunityTasksPath)/MSBuild.Community.Tasks.Targets" />
+  <Import Project="$(MSBuildCommunityTasksPath)/MSBuild.Community.Tasks.Internal.targets" />
 
   <Target Name="Test">
     <User>

--- a/Source/MSBuild.Community.Tasks.Tests/Vault/VaultTest.proj
+++ b/Source/MSBuild.Community.Tasks.Tests/Vault/VaultTest.proj
@@ -29,7 +29,7 @@
 		<NewTestFile2>VaultAddFile2.txt</NewTestFile2>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Targets" />
+	<Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Internal.targets" />
 
 	<Target Name="Checkout">
 		<RemoveDir Directories="$(WorkingFolder)" />

--- a/Source/MSBuild.Community.Tasks.Tests/Xml/XmlMassUpdateTest.proj
+++ b/Source/MSBuild.Community.Tasks.Tests/Xml/XmlMassUpdateTest.proj
@@ -10,7 +10,7 @@
       <xsl:template match="/all" />
     </Substitutions>
   </PropertyGroup>
-  <Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Targets" />
+  <Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Internal.targets" />
 
   <Target Name="DebuggerHook" Condition="'$(DEBUG)'!=''" >
     <Prompt  Text="Attach debugger and press Enter to continue." />

--- a/Source/MSBuild.Community.Tasks.Tests/Xml/XmlQueryTest.proj
+++ b/Source/MSBuild.Community.Tasks.Tests/Xml/XmlQueryTest.proj
@@ -5,7 +5,7 @@
 		<MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == ''">$(MSBuildExtensionsPath)/MSBuildCommunityTasks</MSBuildCommunityTasksPath>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Targets" />
+	<Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Internal.targets" />
 
 	<Target Name="LoadSampleFile">
 		<ReadLinesFromFile File="Test_XmlQuery.xml">

--- a/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Internal.Targets
+++ b/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Internal.Targets
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- $Id$ -->
+
+  <PropertyGroup>
+    <MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == ''">$(MSBuildExtensionsPath)\MSBuildCommunityTasks</MSBuildCommunityTasksPath>
+    <MSBuildCommunityTasksLib>$([MSBUILD]::Unescape($(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.dll))</MSBuildCommunityTasksLib>
+  </PropertyGroup>
+
+  <Import Project="MSBuild.Community.Tasks.targets"/>
+  
+  <ItemGroup>
+    <FxCopRuleAssemblies Include="UsageRules.dll"/>
+    <FxCopRuleAssemblies Include="SecurityRules.dll"/>
+    <FxCopRuleAssemblies Include="PortabilityRules.dll"/>
+    <FxCopRuleAssemblies Include="PerformanceRules.dll"/>
+    <FxCopRuleAssemblies Include="MobilityRules.dll"/>
+    <FxCopRuleAssemblies Include="InteroperabilityRules.dll"/>
+    <FxCopRuleAssemblies Include="GlobalizationRules.dll"/>
+    <FxCopRuleAssemblies Include="DesignRules.dll"/>
+  </ItemGroup>
+</Project>

--- a/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Targets
+++ b/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Targets
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- $Id$ -->
-
   <PropertyGroup>
-    <MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == ''">$(MSBuildExtensionsPath)\MSBuildCommunityTasks</MSBuildCommunityTasksPath>
-    <MSBuildCommunityTasksLib>$([MSBUILD]::Unescape($(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.dll))</MSBuildCommunityTasksLib>
+    <MSBuildCommunityTasksLib Condition=" '$(MSBuildCommunityTasksLib)' == '' ">$(MSBuildThisFileDirectory)MSBuild.Community.Tasks.dll</MSBuildCommunityTasksLib>
   </PropertyGroup>
 
   <UsingTask AssemblyFile="$(MSBuildCommunityTasksLib)" TaskName="MSBuild.Community.Tasks.AspNet.InstallAspNet" />
@@ -137,15 +134,4 @@
   <UsingTask AssemblyFile="$(MSBuildCommunityTasksLib)" TaskName="MSBuild.Community.Tasks.Git.GitBranch" />
   <UsingTask AssemblyFile="$(MSBuildCommunityTasksLib)" TaskName="MSBuild.Community.Tasks.Git.GitDescribe" />
   <UsingTask AssemblyFile="$(MSBuildCommunityTasksLib)" TaskName="MSBuild.Community.Tasks.Git.GitPendingChanges" />
-
-  <ItemGroup>
-    <FxCopRuleAssemblies Include="UsageRules.dll"/>
-    <FxCopRuleAssemblies Include="SecurityRules.dll"/>
-    <FxCopRuleAssemblies Include="PortabilityRules.dll"/>
-    <FxCopRuleAssemblies Include="PerformanceRules.dll"/>
-    <FxCopRuleAssemblies Include="MobilityRules.dll"/>
-    <FxCopRuleAssemblies Include="InteroperabilityRules.dll"/>
-    <FxCopRuleAssemblies Include="GlobalizationRules.dll"/>
-    <FxCopRuleAssemblies Include="DesignRules.dll"/>
-  </ItemGroup>
 </Project>

--- a/Source/MSBuild.Community.Tasks/Mks.proj
+++ b/Source/MSBuild.Community.Tasks/Mks.proj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="All">
     
-	<Import Project="MSBuild.Community.Tasks.Targets" />
+	<Import Project="MSBuild.Community.Tasks.Internal.targets" />
 
 	<PropertyGroup>
 		<ProjectDir>C:\data\OpenSource\MSBuild\Community\MSBuild.Community.Tasks\Source</ProjectDir>

--- a/Source/Sample.proj
+++ b/Source/Sample.proj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="All"  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Required Import to use MSBuild Community Tasks -->
-  <Import Project="$(MSBuildExtensionsPath)\MSBuildCommunityTasks\MSBuild.Community.Tasks.Targets"/>
+  <Import Project="$(MSBuildExtensionsPath)\MSBuildCommunityTasks\MSBuild.Community.Tasks.Internal.targets"/>
   
   <!-- These are sample targets the demonstrate the use of MSBuild Community Tasks  -->
   <Target Name="AssemblyInfo">    

--- a/Source/Sandcastle.proj
+++ b/Source/Sandcastle.proj
@@ -6,7 +6,7 @@
 		<MSBuildCommunityTasksPath>$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\bin\Debug</MSBuildCommunityTasksPath>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\MSBuild.Community.Tasks.Targets"/>
+	<Import Project="$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\MSBuild.Community.Tasks.Internal.targets"/>
 
   <ItemGroup>
     <Assemblies Include="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.dll" />

--- a/Source/Script.proj
+++ b/Source/Script.proj
@@ -6,7 +6,7 @@
 		<MSBuildCommunityTasksPath>$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\bin\Debug</MSBuildCommunityTasksPath>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\MSBuild.Community.Tasks.Targets"/>
+	<Import Project="$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\MSBuild.Community.Tasks.Internal.targets"/>
 	<PropertyGroup>
 		<Code>
 			<![CDATA[

--- a/Source/Services.proj
+++ b/Source/Services.proj
@@ -6,7 +6,7 @@
 		<MSBuildCommunityTasksPath>$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\bin\Debug</MSBuildCommunityTasksPath>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\MSBuild.Community.Tasks.Targets"/>
+	<Import Project="$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\MSBuild.Community.Tasks.Internal.targets"/>
 
 	<Target Name="Test">
 		<CallTarget Targets="DoesServiceExist" />

--- a/Source/Sleep.proj
+++ b/Source/Sleep.proj
@@ -6,7 +6,7 @@
 		<MSBuildCommunityTasksPath>$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\bin\Debug</MSBuildCommunityTasksPath>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\MSBuild.Community.Tasks.Targets"/>
+	<Import Project="$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\MSBuild.Community.Tasks.Internal.targets"/>
 
 	<Target Name="Sleep">
 		<Sleep Milliseconds="200" />

--- a/Source/SourceServer.proj
+++ b/Source/SourceServer.proj
@@ -5,7 +5,7 @@
     <MSBuildCommunityTasksPath>$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\bin\Debug</MSBuildCommunityTasksPath>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\MSBuild.Community.Tasks.Targets"/>
+  <Import Project="$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\MSBuild.Community.Tasks.Internal.targets"/>
 
   <ItemGroup>
     <SymbolFiles Include="MSBuild.Community.Tasks\bin\Debug\*.pdb" />

--- a/Source/Subversion.proj
+++ b/Source/Subversion.proj
@@ -13,7 +13,7 @@
 	<LocalTestRepositoryPath>file:///d:/svn/repo/Test/trunk</LocalTestRepositoryPath>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\MSBuild.Community.Tasks.Targets" />
+  <Import Project="$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\MSBuild.Community.Tasks.Internal.targets" />
 
   <Target Name="Version">
     <SvnVersion LocalPath="$(MSBuildProjectDirectory)">

--- a/Source/Task.proj
+++ b/Source/Task.proj
@@ -6,7 +6,7 @@
     <MSBuildCommunityTasksPath>$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\bin\Debug</MSBuildCommunityTasksPath>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\MSBuild.Community.Tasks.Targets"/>
+  <Import Project="$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\MSBuild.Community.Tasks.Internal.targets"/>
 
   <Target Name="AssemblyInfo">
     <MakeDir Directories="$(MSBuildProjectDirectory)\Test" />

--- a/Source/Vss.proj
+++ b/Source/Vss.proj
@@ -6,7 +6,7 @@
 		<MSBuildCommunityTasksPath>$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\bin\Debug</MSBuildCommunityTasksPath>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\MSBuild.Community.Tasks.Targets"/>
+	<Import Project="$(MSBuildProjectDirectory)\MSBuild.Community.Tasks\MSBuild.Community.Tasks.Internal.targets"/>
 
 	<Target Name="Default">
 

--- a/Tools/Build.proj
+++ b/Tools/Build.proj
@@ -4,7 +4,7 @@
     <MSBuildCommunityTasksPath>$(MSBuildProjectDirectory)\.build</MSBuildCommunityTasksPath>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.targets"/>
+  <Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Internal.targets"/>
 
   <!-- Version Number -->
   <PropertyGroup Condition=" '$(BUILD_NUMBER)' == '' ">


### PR DESCRIPTION
...and into an internal one.

All internal imports of the public file have been redirected to the internal one to keep the own-build semantics the same.

Fixes #126
