### PR TITLE
Extended FtpUploadDirectoryContent with support for setting file transfer type (Binary or ASCII)

### DIFF
--- a/Source/MSBuild.Community.Tasks/Ftp/FtpClientTaskBase.cs
+++ b/Source/MSBuild.Community.Tasks/Ftp/FtpClientTaskBase.cs
@@ -327,6 +327,32 @@ namespace MSBuild.Community.Tasks.Ftp
         }
 
         /// <summary>
+        /// Sets the type of file to be transferred.
+        /// </summary>
+        /// <param name="mode">File transfer type: BINARY or ASCII</param>
+        public void SetFileTransferType( String mode )
+        {
+            if (!mode.Equals("binary", StringComparison.InvariantCultureIgnoreCase)
+                && !mode.Equals("ascii", StringComparison.InvariantCultureIgnoreCase))
+            {
+                CloseAndTrowException(new FtpException("Set file transfer type accepts only following values: 'BINARY' or 'ASCII'."));
+            }
+
+            String rawCommand = mode.Equals("binary", StringComparison.InvariantCultureIgnoreCase)
+                ? "TYPE I"
+                : "TYPE A";
+
+            // Send user command and read reply.
+            FtpReply reply = SendCommandAndReadResponse(rawCommand);
+
+            // If setting file transfer mode was not accepted.
+            if (reply.ResultCode != 200)
+            {
+                CloseAndTrowException(new FtpException(reply.Message));
+            }
+        }
+
+        /// <summary>
         /// Changes the working directory.
         /// </summary>
         /// <param name="remoteDirectory">The remote directory.</param>

--- a/Source/MSBuild.Community.Tasks/Ftp/FtpUploadDirectoryContent.cs
+++ b/Source/MSBuild.Community.Tasks/Ftp/FtpUploadDirectoryContent.cs
@@ -46,6 +46,7 @@ namespace MSBuild.Community.Tasks.Ftp
     {
         private String _localDirectory;
         private String _remoteDirectory;
+        private String _filesTransferType;
         private bool _recursive;
 
         /// <summary>
@@ -77,6 +78,22 @@ namespace MSBuild.Community.Tasks.Ftp
             set
             {
                 _remoteDirectory = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the type of files to be transferred. Accepts either 'BINARY' or 'ASCII' value.
+        /// </summary>
+        /// <value>Files transfer type.</value>
+        public string FilesTransferType
+        {
+            get
+            {
+                return _filesTransferType;
+            }
+            set
+            {
+                _filesTransferType = value;
             }
         }
 
@@ -121,12 +138,27 @@ namespace MSBuild.Community.Tasks.Ftp
                 try
                 {
                     Login();
-                    Log.LogMessage( MessageImportance.Low, "Login succeed." );
+                    Log.LogMessage(MessageImportance.Low, "Login succeed.");
                 }
-                catch(Exception caught)
+                catch (Exception caught)
                 {
-                    Log.LogErrorFromException( caught, false );
-                    Log.LogError( "Couldn't login." );
+                    Log.LogErrorFromException(caught, false);
+                    Log.LogError("Couldn't login.");
+                    return false;
+                }
+
+                try
+                {
+                    if (!String.IsNullOrEmpty(FilesTransferType))
+                    {
+                        SetFileTransferType(FilesTransferType);
+                        Log.LogMessage(MessageImportance.Low, String.Format("File transfer mode set to '{0}'.",FilesTransferType));
+                    }
+                }
+                catch (Exception caught)
+                {
+                    Log.LogErrorFromException(caught, false);
+                    Log.LogError("Couldn't set file transfer mode.");
                     return false;
                 }
 


### PR DESCRIPTION
Extended FtpUploadDirectoryContent with support for new attribute "FileTransferType" which allows to modify file transfer type between default ASCII and BINARY. It is very important for uploading to FTP text files or MSI packages. If ASCII mode is active files get corrupted and modified. This change solves this issue allowing users to overwrite default type and set binary mode.

More about File Transfer Type:
http://www.serv-u.com/newsletter/NewsL2008-03-18.asp

"FileTransferMode" name is used instead of type sometimes however the RAW FTP command is called "TYPE" and command "MODE" stands for different option so not to make it confused with "MODE" raw command i decided to stick to the official FTP documnation and call it "FilesTransferType".

Regards! :)
Przemek
