### PR TITLE
Prevent error MSB6001: Invalid command line switch for "git.exe". Value cannot be null.

### DIFF
--- a/Source/MSBuild.Community.Tasks/ToolPathUtil.cs
+++ b/Source/MSBuild.Community.Tasks/ToolPathUtil.cs
@@ -75,6 +75,9 @@ namespace MSBuild.Community.Tasks
 
         public static string FindInLocalPath(string toolName, string localPath)
         {
+            if (localPath == null)
+                return null;
+
             string path = new DirectoryInfo(localPath).FullName;
             if (SafeFileExists(localPath, toolName))
             {


### PR DESCRIPTION
Prevent exception and thus incorrect MSbuild error when LocalPath is null (the default)
