### PR TITLE
Use XDocument instead of XmlDocument

### DIFF
--- a/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.csproj
+++ b/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.csproj
@@ -59,6 +59,7 @@
     <Reference Include="System.Management" />
     <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\GlobalAssemblyInfo.cs">

--- a/Source/MSBuild.Community.Tasks/XmlUpdate.cs
+++ b/Source/MSBuild.Community.Tasks/XmlUpdate.cs
@@ -31,9 +31,11 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using System.Linq;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
 using System.Xml.XPath;
+using System.Xml.Linq;
 
 
 
@@ -152,35 +154,50 @@ namespace MSBuild.Community.Tasks
             try
             {
                 Log.LogMessage(Properties.Resources.XmlUpdateDocument, _xmlFileName);
-                
-                XmlDocument document = new XmlDocument();
-                document.Load(_xmlFileName);
-                
-                XPathNavigator navigator = document.CreateNavigator();                
-                XmlNamespaceManager manager = new XmlNamespaceManager(navigator.NameTable);
+                                
+                XDocument xdoc = XDocument.Load(_xmlFileName);
+                XmlNamespaceManager manager = new XmlNamespaceManager(new NameTable());
 
                 if (!string.IsNullOrEmpty(_prefix) && !string.IsNullOrEmpty(_namespace))
                 {
                     manager.AddNamespace(_prefix, _namespace);
                 }
+
                 
-                XPathExpression expression = XPathExpression.Compile(_xpath, manager);                
-                XPathNodeIterator nodes = navigator.Select(expression);
+                var items = xdoc.XPathEvaluate(_xpath, manager) as IEnumerable<object>;
+                
+                Log.LogMessage(Properties.Resources.XmlUpdateNodes, items.Count());
 
-                Log.LogMessage(Properties.Resources.XmlUpdateNodes, nodes.Count);
-
-                while (nodes.MoveNext())
-                    if (_delete)
-                        nodes.Current.DeleteSelf();
-                    else
-                        nodes.Current.SetValue(_value ?? string.Empty);
-
-                using (XmlTextWriter writer = new XmlTextWriter(_xmlFileName, Encoding.UTF8))
+                foreach (var item in items.ToArray())
                 {
-                    writer.Formatting = Formatting.Indented;
-                    document.Save(writer);
-                    writer.Close();                    
+                    var attr = item as XAttribute;
+                    if (attr != null)
+                    {
+                        if (_delete)
+                        {
+                            attr.Remove();
+                        }
+                        else
+                        {
+                            attr.SetValue(_value);
+                        }
+                    }
+
+                    var ele = item as XElement;
+                    if (ele != null)
+                    {
+                        if (_delete)
+                        {
+                            ele.Remove();
+                        }
+                        else
+                        {
+                            ele.SetValue(_value);
+                        }
+                    }
                 }
+
+                xdoc.Save(_xmlFileName);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
XmlUpdate:
I had the problem that loading a svg document with XmlDocument takes a half minute.
Using the XDocument solves the bad perfomance.
This patch also solves the isssue #137 
