### PR TITLE
Xslt task failed with XSLT compilation error

### DIFF
--- a/Source/MSBuild.Community.Tasks/Xslt/Xslt.cs
+++ b/Source/MSBuild.Community.Tasks/Xslt/Xslt.cs
@@ -262,11 +262,11 @@ namespace MSBuild.Community.Tasks
 			{
                 if(useTrusted) 
                 {
-                    transform.Load(xsl.ItemSpec, XsltSettings.TrustedXslt, new XmlUrlResolver());
+                    transform.Load(xsl.ItemSpec, XsltSettings.TrustedXslt, null);
                 }
                 else
                 {   
-                    transform.Load(xsl.ItemSpec, XsltSettings.Default, null);
+                    transform.Load(xsl.ItemSpec, XsltSettings.Default, new XmlUrlResolver());
                 }
 
 				xmlWriter = XmlWriter.Create(this.output, transform.OutputSettings);


### PR DESCRIPTION
A previous change to the Xslt task caused it to not be passed an XmlUrlResolver, this prevents paths to includes within an XSLT from being resolved and thus prevents compilation of the XSLT. Modified to pass in an XmlUrlResolver (the default implementation) when useTrusted == falsel; When useTrusted==true we probably don't want to trust external/include files so in that mode I chose to revert back to no resolver (but I'm not completely sure that is correct).

Thanks.
