### PR TITLE
Added parameter "OnlyIfChanged" to AssemblyInfo task to avoid recompilations

### DIFF
--- a/Source/MSBuild.Community.Tasks.Tests/AssemblyInfoTest.cs
+++ b/Source/MSBuild.Community.Tasks.Tests/AssemblyInfoTest.cs
@@ -184,6 +184,32 @@ namespace MSBuild.Community.Tasks.Tests
             Assert.That(content.Contains("assembly: System.Security.AllowPartiallyTrustedCallers()"));
         }
 
+        [Test(Description = "Create VersionInfo twice with OnlyIfChanged set and make sure it wasn't recreated the second time")]
+        public void AssemblyInfoNotRecreatedIfUnchanged()
+        {
+            AssemblyInfo task = new AssemblyInfo();
+            task.BuildEngine = new MockBuild();
+            task.CodeLanguage = "cs";
+            string outputFile = Path.Combine(testDirectory, "VersionInfoTwice.cs");
+            task.OutputFile = outputFile;
+            task.AssemblyVersion = "1.2.3.4";
+            task.AssemblyFileVersion = "1.2.3.4";
+            task.AssemblyInformationalVersion = "1.2.3.4";
+            task.GenerateClass = true;
+            task.OnlyIfChanged = true;
+
+            Assert.IsTrue(task.Execute(), "Execute Failed");
+            Assert.IsTrue(File.Exists(outputFile), "File missing: " + outputFile);
+
+            var time = File.GetLastWriteTime(outputFile);
+
+            // Create again, with OnlyIfChanged set it should not be recreated
+            Assert.IsTrue(task.Execute(), "Second execute failed");
+
+            var secondTime = File.GetLastWriteTime(outputFile);
+            Assert.AreEqual(time, secondTime, "File was recreated although it shouldn't be");
+        }
+
         private AssemblyInfo CreateCSAssemblyInfo(string outputFile)
         {
             AssemblyInfo task = new AssemblyInfo();

--- a/Source/MSBuild.Community.Tasks/AssemblyInfo.cs
+++ b/Source/MSBuild.Community.Tasks/AssemblyInfo.cs
@@ -437,6 +437,11 @@ namespace MSBuild.Community.Tasks
         public string UltimateResourceFallbackLocation { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the file should be generated only if different from any already existing file
+        /// </summary>
+        public bool OnlyIfChanged { get; set; }
+
+        /// <summary>
         /// Makes it possible to make certain assemblies able to use constructs marked as internal.
         /// Example might be setting this value to "UnitTests" assembly. The typical use case might 
         /// be constructors in classes which shouldn't be available to other assemblies, but the unit
@@ -491,12 +496,41 @@ namespace MSBuild.Community.Tasks
 
             Encoding utf8WithSignature = new UTF8Encoding(true);
 
-            using (StreamWriter writer = new StreamWriter(_outputFile, false, utf8WithSignature))
+            if (OnlyIfChanged && File.Exists(_outputFile))
             {
-                GenerateFile(writer);
-                writer.Flush();
-                writer.Close();
-                Log.LogMessage("Created AssemblyInfo file \"{0}\".", _outputFile);
+                // The file already exists. If we generate an identical file, don't overwrite the existing one
+                using (var memoryStream = new MemoryStream())
+                {
+                    using (StreamWriter writer = new StreamWriter(memoryStream, utf8WithSignature))
+                    {
+                        GenerateFile(writer);
+                        writer.Flush();
+
+                        using (var existingFile = File.OpenRead(_outputFile))
+                        {
+                            memoryStream.Seek(0, SeekOrigin.Begin);
+
+                            if (StreamTools.StreamEquals(existingFile, memoryStream))
+                            {
+                                Log.LogMessage("Identical AssemblyInfo file \"{0}\" already exists.", _outputFile);
+                                return true;
+                            }
+                        }
+
+                        File.WriteAllBytes(_outputFile, memoryStream.ToArray());
+                        Log.LogMessage("Created updated AssemblyInfo file \"{0}\".", _outputFile);
+                    }
+                }
+            }
+            else 
+            { 
+                using (StreamWriter writer = new StreamWriter(_outputFile, false, utf8WithSignature))
+                {
+                    GenerateFile(writer);
+                    writer.Flush();
+                    writer.Close();
+                    Log.LogMessage("Created AssemblyInfo file \"{0}\".", _outputFile);
+                }
             }
 
             return true;

--- a/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.csproj
+++ b/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.csproj
@@ -172,6 +172,7 @@
     <Compile Include="SourceServer\SymbolFile.cs" />
     <Compile Include="SourceServer\TfsSourceIndex.cs" />
     <Compile Include="SqlServer\SqlPubWiz.cs" />
+    <Compile Include="StreamTools.cs" />
     <Compile Include="Subversion\SvnCopy.cs" />
     <Compile Include="Subversion\Info.cs" />
     <Compile Include="Subversion\SvnStatus.cs" />

--- a/Source/MSBuild.Community.Tasks/StreamTools.cs
+++ b/Source/MSBuild.Community.Tasks/StreamTools.cs
@@ -1,0 +1,30 @@
+﻿using System.IO;
+using System.Linq;
+
+namespace MSBuild.Community.Tasks
+{
+    internal static class StreamTools
+    {
+        public static bool StreamEquals(Stream stream1, Stream stream2)
+        {
+            const int bufferSize = 2048;
+            byte[] buffer1 = new byte[bufferSize]; //buffer size
+            byte[] buffer2 = new byte[bufferSize];
+            while (true)
+            {
+                int count1 = stream1.Read(buffer1, 0, bufferSize);
+                int count2 = stream2.Read(buffer2, 0, bufferSize);
+
+                if (count1 != count2)
+                    return false;
+
+                if (count1 == 0)
+                    return true;
+
+                // You might replace the following with an efficient "memcmp"
+                if (!buffer1.Take(count1).SequenceEqual(buffer2.Take(count2)))
+                    return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
When recompiling big projects with this tool all projects needs to be recompiled every time since the generated file changes date (even if it's identical).

I added a parameter "OnlyIfChanged" to the AssemblyInfo task; when true it checks if any existing file is identical, if so it doesn't update the file (and thus keeps the date unchanged). This allows the compilation of projects to be skipped if it's up to date.