### PR TITLE
Makes NuGet package add itself to projects.

### DIFF
--- a/MSBuildTasks.Project.nuspec
+++ b/MSBuildTasks.Project.nuspec
@@ -9,15 +9,12 @@
     <projectUrl>https://github.com/loresoft/msbuildtasks/</projectUrl>
     <licenseUrl>http://opensource.org/licenses/bsd-license.php</licenseUrl>
     <tags>MSBuild</tags>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
-    <file src="Build\MSBuild.Community.Tasks.dll" target="tools\MSBuild.Community.Tasks.dll" />
-    <file src="Build\MSBuild.Community.Tasks.xml" target="tools\MSBuild.Community.Tasks.xml" />
-    <file src="Build\MSBuild.Community.Tasks.Targets" target="tools\MSBuild.Community.Tasks.Targets" />
+    <file src="Build\MSBuild.Community.Tasks.dll" target="build" />
+    <file src="Build\MSBuild.Community.Tasks.xml" target="build" />
+    <file src="Build\MSBuild.Community.Tasks.Targets" target="build" />
     <file src="readme.md" target="content\MSBuild.Community.Tasks.ReadMe.md" />
-    <file src="Tools\Build.proj" target="tools\Build.proj" />
-    <file src="Tools\Install.Project.ps1" target="tools\Install.ps1" />
-    <file src="Tools\Uninstall.Project.ps1" target="tools\Uninstall.ps1" />
-    <file src="Tools\MSBuild.psm1" target="tools\MSBuild.psm1" />
   </files>
 </package>

--- a/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Targets
+++ b/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Targets
@@ -3,7 +3,7 @@
   <!-- $Id$ -->
 
   <PropertyGroup>
-    <MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == ''">$(MSBuildExtensionsPath)\MSBuildCommunityTasks</MSBuildCommunityTasksPath>
+    <MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == ''">$(MSBuildThisFileDirectory)</MSBuildCommunityTasksPath>
     <MSBuildCommunityTasksLib>$([MSBUILD]::Unescape($(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.dll))</MSBuildCommunityTasksLib>
   </PropertyGroup>
 


### PR DESCRIPTION
https://docs.nuget.org/create/creating-and-publishing-a-package#from-a-convention-based-working-directory

A while back, NuGet added support for convertion-based folder called "build".  Any .targets file that is found in this folder will be imported into the project file this NuGet package is added to.

This resolves https://github.com/loresoft/msbuildtasks/issues/144, since there is no longer any on-install script that places files where they need to be.  Also, this pattern makes it so projects the NuGet package is added to get access to the all of the tasks immediately, without the user having to import the tasks themselves.