### PR TITLE
Enable Css Compression Task

### DIFF
--- a/Source/MSBuild.Community.Tasks/JavaScript/CssCompressor.cs
+++ b/Source/MSBuild.Community.Tasks/JavaScript/CssCompressor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.IO;
@@ -46,6 +46,7 @@ namespace MSBuild.Community.Tasks.JavaScript
             RemoveComments();
             // trim whitespace from the start and end
             cssContent = cssContent.Trim();
+            return cssContent;
         }
 
         private void RemoveComments()

--- a/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Targets
+++ b/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Targets
@@ -113,6 +113,7 @@
   <UsingTask AssemblyFile="$(MSBuildCommunityTasksLib)" TaskName="MSBuild.Community.Tasks.Zip" />
 
   <UsingTask AssemblyFile="$(MSBuildCommunityTasksLib)" TaskName="MSBuild.Community.Tasks.JavaScript.JSCompress" />
+  <UsingTask AssemblyFile="$(MSBuildCommunityTasksLib)" TaskName="MSBuild.Community.Tasks.JavaScript.CSSCompress" />
 
   <UsingTask AssemblyFile="$(MSBuildCommunityTasksLib)" TaskName="MSBuild.Community.Tasks.User" />
   <UsingTask AssemblyFile="$(MSBuildCommunityTasksLib)" TaskName="MSBuild.Community.Tasks.Computer" />

--- a/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Targets
+++ b/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Targets
@@ -113,7 +113,7 @@
   <UsingTask AssemblyFile="$(MSBuildCommunityTasksLib)" TaskName="MSBuild.Community.Tasks.Zip" />
 
   <UsingTask AssemblyFile="$(MSBuildCommunityTasksLib)" TaskName="MSBuild.Community.Tasks.JavaScript.JSCompress" />
-  <UsingTask AssemblyFile="$(MSBuildCommunityTasksLib)" TaskName="MSBuild.Community.Tasks.JavaScript.CSSCompress" />
+  <UsingTask AssemblyFile="$(MSBuildCommunityTasksLib)" TaskName="MSBuild.Community.Tasks.JavaScript.CssCompress" />
 
   <UsingTask AssemblyFile="$(MSBuildCommunityTasksLib)" TaskName="MSBuild.Community.Tasks.User" />
   <UsingTask AssemblyFile="$(MSBuildCommunityTasksLib)" TaskName="MSBuild.Community.Tasks.Computer" />

--- a/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.csproj
+++ b/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -123,6 +123,8 @@
     <Compile Include="HtmlHelp\ChmCompiler.cs" />
     <Compile Include="HtmlHelp\HxCompiler.cs" />
     <Compile Include="InnoSetup.cs" />
+    <Compile Include="JavaScript\CssCompress.cs" />
+    <Compile Include="JavaScript\CssCompressor.cs" />
     <Compile Include="Merge.cs" />
     <Compile Include="Net\HttpRequest.cs" />
     <Compile Include="NuGet\NuGetBase.cs" />

--- a/readme.md
+++ b/readme.md
@@ -213,6 +213,10 @@ https://groups.google.com/d/forum/msbuildtasks
 		downloads and code that is harder to read.</td>
 	</tr>
 	<tr>
+		<td>CssCompress</td>
+		<td>Compresses CSS source by removing comments and unnecessary whitespace.</td>
+	</tr>
+	<tr>
 		<td>MRefBuilder</td>
 		<td>MRefBuilder task for Sandcastle.</td>
 	</tr>


### PR DESCRIPTION
I have been using the CSS compression for over a year with a custom build. It would be useful to have it part of the Nuget package. I have corrected the issue that caused it not to build and added the task.