### PR TITLE
Pattern matching and Lightweight tag support to GitDescribe

### DIFF
--- a/Source/MSBuild.Community.Tasks/Git/GitDescribe.cs
+++ b/Source/MSBuild.Community.Tasks/Git/GitDescribe.cs
@@ -80,6 +80,15 @@ namespace MSBuild.Community.Tasks.Git
         /// </summary>
         public bool SoftErrorMode { get; set; }
 
+        /// <summary>
+        /// When true, will use unannotated tags
+        /// </summary>
+        public bool LightWeight { get; set; }
+
+        /// <summary>
+        /// Matches the specified pattern
+        /// </summary>
+        public string Match { get; set; }
 
         /// <summary>
         /// Make sure we specify abbrev=40 to get full CommitHash
@@ -88,6 +97,10 @@ namespace MSBuild.Community.Tasks.Git
         protected override void GenerateArguments(CommandLineBuilder builder)
         {
             builder.AppendSwitch("--long --abbrev=40");
+            if (LightWeight)
+                builder.AppendSwitch("--tags");
+            if (!String.IsNullOrEmpty(Match))
+                builder.AppendSwitch("--match '" + Match + "'");
             base.GenerateArguments(builder);
         }
 


### PR DESCRIPTION
* Add Pattern Matching (--match) support to GitDescribe
* Add Lightweight tags (--tags) support to GitDescribe

In case of a branch with multiple tags, only the most recent is returned with git describe.

##### Situational Example
*Assuming both tags are annotated or not, not one annotated and the other lightweight*

If a version tag **[v1.0.0]** was created before another tag **[tag]**, only the most recent one will be shown in git describe, **[tag]**.
Adding a Match pattern of **"v[0-9]*"** will again return the most recent version tag, alongside the commit count after it, instead of the last tag added