### PR TITLE
mono/xbuild does not support the [MSBUILD]::Unescape syntax, so don't use it on Linux

### DIFF
--- a/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Targets
+++ b/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Targets
@@ -4,7 +4,8 @@
 
   <PropertyGroup>
     <MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == ''">$(MSBuildThisFileDirectory)</MSBuildCommunityTasksPath>
-    <MSBuildCommunityTasksLib>$([MSBUILD]::Unescape($(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.dll))</MSBuildCommunityTasksLib>
+    <MSBuildCommunityTasksLib Condition="'$(OS)' == 'Windows_NT'">$([MSBUILD]::Unescape($(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.dll))</MSBuildCommunityTasksLib>
+    <MSBuildCommunityTasksLib Condition="'$(OS)' != 'Windows_NT'">$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.dll)</MSBuildCommunityTasksLib>
     <MSBuildCommunityTasksLib Condition="!Exists('$(MSBuildCommunityTasksLib)')">MSBuild.Community.Tasks.dll</MSBuildCommunityTasksLib>
   </PropertyGroup>
 


### PR DESCRIPTION
Using the msbuildtasks with xbuild on Linux doesn't work because of the `[MSBUILD]::Unescape`  syntax; this pull request works around that (on non-Windows operating systems).