### PR TITLE
Changing the Zip task to accept relative paths. "Dir\\..\\file.txt"

### DIFF
--- a/Source/MSBuild.Community.Tasks.Tests/ZipTest.cs
+++ b/Source/MSBuild.Community.Tasks.Tests/ZipTest.cs
@@ -1,6 +1,9 @@
 
 
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using Ionic.Zip;
 using Microsoft.Build.Utilities;
 using NUnit.Framework;
 
@@ -14,6 +17,7 @@ namespace MSBuild.Community.Tasks.Tests
     {
         public const string ZIP_FILE_NAME = @"MSBuild.Community.Tasks.zip";
         public const string ZIP_WITH_FOLDERS_FILE_NAME = @"MSBuild.Community.Tasks.WithFolders.zip";
+        public const string ZIP_WITH_RELATIVE_FILE_NAME = @"MSBuild.Community.Tasks.WithReltive.zip";
 
         [Test(Description = "Zip files into a zip archive")]
         public void ZipExecute()
@@ -96,6 +100,33 @@ namespace MSBuild.Community.Tasks.Tests
 
             Assert.IsTrue(task.Execute(), "Execute Failed");
             Assert.IsTrue(File.Exists(task.ZipFileName), "Zip file not found");
+        }
+
+        [Test(Description = "Zip files with relative path")]
+        public void ZipRelativeExecute()
+        {
+            var task = new Zip();
+            task.BuildEngine = new MockBuild();
+
+            string testDir = TaskUtility.TestDirectory;
+            string prjRootPath = TaskUtility.GetProjectRootDirectory(true);
+
+            string workingDir = Path.Combine(prjRootPath, @"Source\MSBuild.Community.Tasks.Tests");
+            List<string> files = Directory.GetFiles(workingDir, "*.*", SearchOption.TopDirectoryOnly).ToList();
+            files.Add(Path.Combine(workingDir, "..\\..\\readme.md"));
+
+            TaskItem[] items = TaskUtility.StringArrayToItemArray(files.ToArray());
+
+            task.Files = items;
+            task.WorkingDirectory = workingDir;
+            task.ZipFileName = Path.Combine(testDir, ZIP_WITH_RELATIVE_FILE_NAME);
+
+            if (File.Exists(task.ZipFileName))
+                File.Delete(task.ZipFileName);
+            
+            Assert.IsTrue(task.Execute(), "Execute Failed");                        
+            Assert.IsTrue(ZipFile.Read(task.ZipFileName).ContainsEntry("readme.md"), "The zip doesnt contains the readme.md file");            
+            Assert.IsTrue(File.Exists(task.ZipFileName), "Zip file not found");            
         }
     }
 }

--- a/Source/MSBuild.Community.Tasks/Zip.cs
+++ b/Source/MSBuild.Community.Tasks/Zip.cs
@@ -247,7 +247,7 @@ namespace MSBuild.Community.Tasks
 
                     foreach (ITaskItem fileItem in Files)
                     {
-                        string name = fileItem.ItemSpec;
+                        string name = Path.GetFullPath(fileItem.ItemSpec);
                         string directoryPathInArchive;
 
                         // clean up name


### PR DESCRIPTION
Hi,

I changed the line which gets the path to the file so it will accept relative paths in the build.