### PR TITLE
NUnit3 Build Task Fix (Supports NUnit 3.2.0)

### DIFF
--- a/Source/MSBuild.Community.Tasks/NUnit3.cs
+++ b/Source/MSBuild.Community.Tasks/NUnit3.cs
@@ -440,6 +440,12 @@ namespace MSBuild.Community.Tasks
             nunitPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
             nunitPath = Path.Combine(nunitPath, DEFAULT_NUNIT_DIRECTORY);
 
+            if (Directory.Exists(nunitPath) == false)
+            {
+                nunitPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+                nunitPath = Path.Combine(nunitPath, DEFAULT_NUNIT_DIRECTORY);    
+            }
+
             try
             {
                 string value = Registry.GetValue(InstallDirKey, "InstallDir", nunitPath) as string;


### PR DESCRIPTION
NUnit 3.2.0 does not install to the Program Files directory on x64 computers. It install to the Program Files x86 and it also doesn't update the registry for where Nunit is installed so you may have Nunit 2.6.3 installed and the Nunit3 task doesn't find the new Nunit 3.2.0 version to run the tests with.