### PR TITLE
Changed namespace prefix handling for XmlUpdate

### DIFF
--- a/Source/MSBuild.Community.Tasks/XmlUpdate.cs
+++ b/Source/MSBuild.Community.Tasks/XmlUpdate.cs
@@ -154,18 +154,23 @@ namespace MSBuild.Community.Tasks
             try
             {
                 Log.LogMessage(Properties.Resources.XmlUpdateDocument, _xmlFileName);
-                                
+
                 XDocument xdoc = XDocument.Load(_xmlFileName);
                 XmlNamespaceManager manager = new XmlNamespaceManager(new NameTable());
 
-                if (!string.IsNullOrEmpty(_prefix) && !string.IsNullOrEmpty(_namespace))
+                if (!string.IsNullOrEmpty(_namespace))
                 {
+                    //by default, if _prefix is not specified, set it to "", this way,
+                    //manager.AddNamespace will add the _namespace as the default namespace
+                    if (_prefix == null)
+                        _prefix = String.Empty;
+
                     manager.AddNamespace(_prefix, _namespace);
                 }
 
-                
+
                 var items = xdoc.XPathEvaluate(_xpath, manager) as IEnumerable<object>;
-                
+
                 Log.LogMessage(Properties.Resources.XmlUpdateNodes, items.Count());
 
                 foreach (var item in items.ToArray())


### PR DESCRIPTION
Changed the way XmlUpdate uses the prefix parameter to allow setting a default namespace by simply omitting or adding a "" value for the prefix argument.

This way, we can specify only a namespace that we wish work in and not need to use a dummy prefix at every level of the xpath parameter's path when the concerned nodes are in the default namespace.

This is documented behavior of  AddNamespace's prefix parameter as per msdn
(see: https://msdn.microsoft.com/en-us/library/system.xml.xmlnamespacemanager.addnamespace(v=vs.110).aspx)