### PR TITLE
Allow to replace/update template file

### DIFF
--- a/Source/MSBuild.Community.Tasks.Tests/TemplateFile/TemplateFileTest.cs
+++ b/Source/MSBuild.Community.Tasks.Tests/TemplateFile/TemplateFileTest.cs
@@ -6,11 +6,11 @@ using NUnit.Framework;
 
 namespace MSBuild.Community.Tasks.Tests
 {
-    [TestFixture]
-    public class TemplateFileTest
-    {
-        private static string _template =
-            @"
+	[TestFixture]
+	public class TemplateFileTest
+	{
+		private static string _template =
+			@"
 			Template File 1
 			${TemplateItem} = TemplateItem
 			{Non-TemplateItem} = NonTemplateItem
@@ -18,199 +18,199 @@ namespace MSBuild.Community.Tasks.Tests
 			${CASEInsenSiTiveTest}
             ${Template.Item.With.Dot}
 		";
-        private static string _templateReplaced =
-            _template.Replace("${TemplateItem}", "**Item1**").Replace("${item2}", "**Item2**")
-                .Replace("${CASEInsenSiTiveTest}", "**Item3**")
-                .Replace("${Template.Item.With.Dot}", "**Item4**");
-        private static string _templateFilename;
-        private string _replacedFilename;
+		private static string _templateReplaced =
+			_template.Replace("${TemplateItem}", "**Item1**").Replace("${item2}", "**Item2**")
+				.Replace("${CASEInsenSiTiveTest}", "**Item3**")
+				.Replace("${Template.Item.With.Dot}", "**Item4**");
+		private static string _templateFilename;
+		private string _replacedFilename;
 
-        [OneTimeSetUp]
-        public void FixtureInit()
-        {
-            MockBuild buildEngine = new MockBuild();
-            TaskUtility.makeTestDirectory(buildEngine);
-            _templateFilename = Path.Combine(TaskUtility.TestDirectory, typeof (TemplateFileTest).Name + ".txt");
-        }
+		[OneTimeSetUp]
+		public void FixtureInit()
+		{
+			MockBuild buildEngine = new MockBuild();
+			TaskUtility.makeTestDirectory(buildEngine);
+			_templateFilename = Path.Combine(TaskUtility.TestDirectory, typeof(TemplateFileTest).Name + ".txt");
+		}
 
-        [SetUp]
-        public void Setup()
-        {
-            File.WriteAllText(_templateFilename, _template);
-            _replacedFilename = null;
-        }
+		[SetUp]
+		public void Setup()
+		{
+			File.WriteAllText(_templateFilename, _template);
+			_replacedFilename = null;
+		}
 
-        [TearDown]
-        public void Teardown()
-        {
-            if (_replacedFilename != null && File.Exists(_replacedFilename))
-            {
-                File.Delete(_replacedFilename);
-            }
-        }
+		[TearDown]
+		public void Teardown()
+		{
+			if (_replacedFilename != null && File.Exists(_replacedFilename))
+			{
+				File.Delete(_replacedFilename);
+			}
+		}
 
-        private void SetMetaData(TaskItem item, string data, bool set)
-        {
-            if (set)
-            {
-                item.SetMetadata(TemplateFile.MetadataValueTag, data);
-            }
-        }
+		private void SetMetaData(TaskItem item, string data, bool set)
+		{
+			if (set)
+			{
+				item.SetMetadata(TemplateFile.MetadataValueTag, data);
+			}
+		}
 
-        private TaskItem[] GetTaskItems()
-        {
-            return GetTaskItems(true);
-        }
+		private TaskItem[] GetTaskItems()
+		{
+			return GetTaskItems(true);
+		}
 
-        private TaskItem[] GetTaskItems(bool includeMetaData)
-        {
-            List<TaskItem> result = new List<TaskItem>();
-            TaskItem item = new TaskItem("TemplateItem");
-            SetMetaData(item, "**Item1**", includeMetaData);
-            result.Add(item);
-            item = new TaskItem("item2");
-            SetMetaData(item, "**Item2**", includeMetaData);
-            result.Add(item);
-            item = new TaskItem("caseInsensitiveTest");
-            SetMetaData(item, "**Item3**", includeMetaData);
-            result.Add(item);
-            item = new TaskItem("Template.Item.With.Dot");
-            SetMetaData(item, "**Item4**", includeMetaData);
-            result.Add(item);
-            return result.ToArray();
-        }
+		private TaskItem[] GetTaskItems(bool includeMetaData)
+		{
+			List<TaskItem> result = new List<TaskItem>();
+			TaskItem item = new TaskItem("TemplateItem");
+			SetMetaData(item, "**Item1**", includeMetaData);
+			result.Add(item);
+			item = new TaskItem("item2");
+			SetMetaData(item, "**Item2**", includeMetaData);
+			result.Add(item);
+			item = new TaskItem("caseInsensitiveTest");
+			SetMetaData(item, "**Item3**", includeMetaData);
+			result.Add(item);
+			item = new TaskItem("Template.Item.With.Dot");
+			SetMetaData(item, "**Item4**", includeMetaData);
+			result.Add(item);
+			return result.ToArray();
+		}
 
-        private TaskItem[] GetTaskItemsMissing()
-        {
-            List<TaskItem> result = new List<TaskItem>();
-            TaskItem item = new TaskItem("TemplateItem");
-            SetMetaData(item, "**Item1**", true);
-            result.Add(item);
-            item = new TaskItem("caseInsensitiveTest");
-            SetMetaData(item, "**Item3**", true);
-            result.Add(item);
-            return result.ToArray();
-        }
+		private TaskItem[] GetTaskItemsMissing()
+		{
+			List<TaskItem> result = new List<TaskItem>();
+			TaskItem item = new TaskItem("TemplateItem");
+			SetMetaData(item, "**Item1**", true);
+			result.Add(item);
+			item = new TaskItem("caseInsensitiveTest");
+			SetMetaData(item, "**Item3**", true);
+			result.Add(item);
+			return result.ToArray();
+		}
 
-        [Test]
-        public void TemplateFileDefault()
-        {
-            MockBuild build = new MockBuild();
-            TemplateFile tf = new TemplateFile();
-            tf.BuildEngine = build;
-            tf.Template = new TaskItem(_templateFilename);
-            tf.Tokens = GetTaskItems();
-            Assert.IsTrue(tf.Execute());
-            Assert.IsNotNull(tf.OutputFile);
-            Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
-            _replacedFilename = tf.OutputFile.ItemSpec;
-            Assert.AreEqual(Path.ChangeExtension(_templateFilename, ".out"), _replacedFilename);
-            string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
-            Assert.AreEqual(_templateReplaced, replaced);
-        }
+		[Test]
+		public void TemplateFileDefault()
+		{
+			MockBuild build = new MockBuild();
+			TemplateFile tf = new TemplateFile();
+			tf.BuildEngine = build;
+			tf.Template = new TaskItem(_templateFilename);
+			tf.Tokens = GetTaskItems();
+			Assert.IsTrue(tf.Execute());
+			Assert.IsNotNull(tf.OutputFile);
+			Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
+			_replacedFilename = tf.OutputFile.ItemSpec;
+			Assert.AreEqual(Path.ChangeExtension(_templateFilename, ".out"), _replacedFilename);
+			string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
+			Assert.AreEqual(_templateReplaced, replaced);
+		}
 
-        [Test]
-        public void TemplateFileInvalidTemplate()
-        {
-            MockBuild build = new MockBuild();
-            TemplateFile tf = new TemplateFile();
-            tf.BuildEngine = build;
-            tf.Template = new TaskItem("non_existant_file");
-            tf.Tokens = GetTaskItems();
-            Assert.IsFalse(tf.Execute());
-            Assert.AreEqual(1, build.ErrorCount);
-        }
+		[Test]
+		public void TemplateFileInvalidTemplate()
+		{
+			MockBuild build = new MockBuild();
+			TemplateFile tf = new TemplateFile();
+			tf.BuildEngine = build;
+			tf.Template = new TaskItem("non_existant_file");
+			tf.Tokens = GetTaskItems();
+			Assert.IsFalse(tf.Execute());
+			Assert.AreEqual(1, build.ErrorCount);
+		}
 
-        [Test]
-        public void TemplateFileNewFilename()
-        {
-            MockBuild build = new MockBuild();
-            TemplateFile tf = new TemplateFile();
-            tf.BuildEngine = build;
-            tf.Template = new TaskItem(_templateFilename);
-            string outputfile = Path.Combine(Path.GetDirectoryName(_templateFilename), "Replacement.file");
-            tf.OutputFilename = outputfile;
-            tf.Tokens = GetTaskItems();
-            Assert.IsTrue(tf.Execute());
-            Assert.IsNotNull(tf.OutputFile);
-            Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
-            _replacedFilename = tf.OutputFile.ItemSpec;
-            Assert.AreEqual(outputfile, _replacedFilename);
-            string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
-            Assert.AreEqual(_templateReplaced, replaced);
-        }
+		[Test]
+		public void TemplateFileNewFilename()
+		{
+			MockBuild build = new MockBuild();
+			TemplateFile tf = new TemplateFile();
+			tf.BuildEngine = build;
+			tf.Template = new TaskItem(_templateFilename);
+			string outputfile = Path.Combine(Path.GetDirectoryName(_templateFilename), "Replacement.file");
+			tf.OutputFilename = outputfile;
+			tf.Tokens = GetTaskItems();
+			Assert.IsTrue(tf.Execute());
+			Assert.IsNotNull(tf.OutputFile);
+			Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
+			_replacedFilename = tf.OutputFile.ItemSpec;
+			Assert.AreEqual(outputfile, _replacedFilename);
+			string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
+			Assert.AreEqual(_templateReplaced, replaced);
+		}
 
-        [Test]
-        public void TemplateFileNoMetaData()
-        {
-            MockBuild build = new MockBuild();
-            TemplateFile tf = new TemplateFile();
-            tf.BuildEngine = build;
-            tf.Template = new TaskItem(_templateFilename);
-            tf.Tokens = GetTaskItems(false);
-            Assert.IsTrue(tf.Execute());
-            Assert.IsNotNull(tf.OutputFile);
-            Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
-            _replacedFilename = tf.OutputFile.ItemSpec;
-            Assert.AreEqual(Path.ChangeExtension(_templateFilename, ".out"), _replacedFilename);
-            string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
-            string shouldBeReplaced =
-                _template.Replace("${TemplateItem}", "").Replace("${item2}", "").Replace("${CASEInsenSiTiveTest}", "")
-                    .Replace("${Template.Item.With.Dot}", "");
-            Assert.AreEqual(shouldBeReplaced, replaced);
-        }
+		[Test]
+		public void TemplateFileNoMetaData()
+		{
+			MockBuild build = new MockBuild();
+			TemplateFile tf = new TemplateFile();
+			tf.BuildEngine = build;
+			tf.Template = new TaskItem(_templateFilename);
+			tf.Tokens = GetTaskItems(false);
+			Assert.IsTrue(tf.Execute());
+			Assert.IsNotNull(tf.OutputFile);
+			Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
+			_replacedFilename = tf.OutputFile.ItemSpec;
+			Assert.AreEqual(Path.ChangeExtension(_templateFilename, ".out"), _replacedFilename);
+			string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
+			string shouldBeReplaced =
+				_template.Replace("${TemplateItem}", "").Replace("${item2}", "").Replace("${CASEInsenSiTiveTest}", "")
+					.Replace("${Template.Item.With.Dot}", "");
+			Assert.AreEqual(shouldBeReplaced, replaced);
+		}
 
-        [Test]
-        public void TemplateFileNoTokens()
-        {
-            MockBuild build = new MockBuild();
-            TemplateFile tf = new TemplateFile();
-            tf.BuildEngine = build;
-            tf.Template = new TaskItem(_templateFilename);
-            Assert.IsTrue(tf.Execute());
-            Assert.IsNotNull(tf.OutputFile);
-            Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
-            _replacedFilename = tf.OutputFile.ItemSpec;
-            Assert.AreEqual(Path.ChangeExtension(_templateFilename, ".out"), _replacedFilename);
-            string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
-            Assert.AreEqual(_template, replaced);
-        }
+		[Test]
+		public void TemplateFileNoTokens()
+		{
+			MockBuild build = new MockBuild();
+			TemplateFile tf = new TemplateFile();
+			tf.BuildEngine = build;
+			tf.Template = new TaskItem(_templateFilename);
+			Assert.IsTrue(tf.Execute());
+			Assert.IsNotNull(tf.OutputFile);
+			Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
+			_replacedFilename = tf.OutputFile.ItemSpec;
+			Assert.AreEqual(Path.ChangeExtension(_templateFilename, ".out"), _replacedFilename);
+			string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
+			Assert.AreEqual(_template, replaced);
+		}
 
-        [Test]
-        public void TemplateFileMissingToken()
-        {
-            MockBuild build = new MockBuild();
-            TemplateFile tf = new TemplateFile();
-            tf.BuildEngine = build;
-            tf.Template = new TaskItem(_templateFilename);
-            tf.Tokens = GetTaskItemsMissing();
-            Assert.IsTrue(tf.Execute());
-            Assert.IsNotNull(tf.OutputFile);
-            Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
-            _replacedFilename = tf.OutputFile.ItemSpec;
-            Assert.AreEqual(Path.ChangeExtension(_templateFilename, ".out"), _replacedFilename);
-            string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
-            string shouldBeReplaced = _template.Replace("${TemplateItem}", "**Item1**")
-                .Replace("${CASEInsenSiTiveTest}", "**Item3**");
-            Assert.AreEqual(shouldBeReplaced, replaced);
-        }
+		[Test]
+		public void TemplateFileMissingToken()
+		{
+			MockBuild build = new MockBuild();
+			TemplateFile tf = new TemplateFile();
+			tf.BuildEngine = build;
+			tf.Template = new TaskItem(_templateFilename);
+			tf.Tokens = GetTaskItemsMissing();
+			Assert.IsTrue(tf.Execute());
+			Assert.IsNotNull(tf.OutputFile);
+			Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
+			_replacedFilename = tf.OutputFile.ItemSpec;
+			Assert.AreEqual(Path.ChangeExtension(_templateFilename, ".out"), _replacedFilename);
+			string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
+			string shouldBeReplaced = _template.Replace("${TemplateItem}", "**Item1**")
+				.Replace("${CASEInsenSiTiveTest}", "**Item3**");
+			Assert.AreEqual(shouldBeReplaced, replaced);
+		}
 
-        [Test]
-        public void TemplateFileReplace()
-        {
-            MockBuild build = new MockBuild();
-            TemplateFile tf = new TemplateFile();
-            tf.BuildEngine = build;
-            tf.Template = new TaskItem(_templateFilename);
-            tf.OutputFilename = _templateFilename;
-            tf.Tokens = GetTaskItems();
-            Assert.IsTrue(tf.Execute());
-            Assert.IsNotNull(tf.OutputFile);
-            Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
-            _replacedFilename = tf.OutputFile.ItemSpec;
-            Assert.AreEqual(_templateFilename, _replacedFilename);
-            string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
-            Assert.AreEqual(_templateReplaced, replaced);
-        }
-    }
+		[Test]
+		public void TemplateFileReplace()
+		{
+			MockBuild build = new MockBuild();
+			TemplateFile tf = new TemplateFile();
+			tf.BuildEngine = build;
+			tf.Template = new TaskItem(_templateFilename);
+			tf.OutputFilename = _templateFilename;
+			tf.Tokens = GetTaskItems();
+			Assert.IsTrue(tf.Execute());
+			Assert.IsNotNull(tf.OutputFile);
+			Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
+			_replacedFilename = tf.OutputFile.ItemSpec;
+			Assert.AreEqual(_templateFilename, _replacedFilename);
+			string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
+			Assert.AreEqual(_templateReplaced, replaced);
+		}
+	}
 }

--- a/Source/MSBuild.Community.Tasks.Tests/TemplateFile/TemplateFileTest.cs
+++ b/Source/MSBuild.Community.Tasks.Tests/TemplateFile/TemplateFileTest.cs
@@ -6,11 +6,11 @@ using NUnit.Framework;
 
 namespace MSBuild.Community.Tasks.Tests
 {
-	[TestFixture]
-	public class TemplateFileTest
-	{
-		private static string _template =
-			@"
+    [TestFixture]
+    public class TemplateFileTest
+    {
+        private static string _template =
+            @"
 			Template File 1
 			${TemplateItem} = TemplateItem
 			{Non-TemplateItem} = NonTemplateItem
@@ -18,180 +18,199 @@ namespace MSBuild.Community.Tasks.Tests
 			${CASEInsenSiTiveTest}
             ${Template.Item.With.Dot}
 		";
-		private static string _templateReplaced =
-			_template.Replace("${TemplateItem}", "**Item1**").Replace("${item2}", "**Item2**")
+        private static string _templateReplaced =
+            _template.Replace("${TemplateItem}", "**Item1**").Replace("${item2}", "**Item2**")
                 .Replace("${CASEInsenSiTiveTest}", "**Item3**")
                 .Replace("${Template.Item.With.Dot}", "**Item4**");
-		private static string _templateFilename;
-		private string _replacedFilename;
+        private static string _templateFilename;
+        private string _replacedFilename;
 
-		[OneTimeSetUp]
-		public void FixtureInit()
-		{
-			MockBuild buildEngine = new MockBuild();
-			TaskUtility.makeTestDirectory(buildEngine);
-			_templateFilename = Path.Combine(TaskUtility.TestDirectory, typeof (TemplateFileTest).Name + ".txt");
-		}
+        [OneTimeSetUp]
+        public void FixtureInit()
+        {
+            MockBuild buildEngine = new MockBuild();
+            TaskUtility.makeTestDirectory(buildEngine);
+            _templateFilename = Path.Combine(TaskUtility.TestDirectory, typeof (TemplateFileTest).Name + ".txt");
+        }
 
-		[SetUp]
-		public void Setup()
-		{
-			File.WriteAllText(_templateFilename, _template);
-			_replacedFilename = null;
-		}
+        [SetUp]
+        public void Setup()
+        {
+            File.WriteAllText(_templateFilename, _template);
+            _replacedFilename = null;
+        }
 
-		[TearDown]
-		public void Teardown()
-		{
-			if (_replacedFilename != null && File.Exists(_replacedFilename))
-			{
-				File.Delete(_replacedFilename);
-			}
-		}
+        [TearDown]
+        public void Teardown()
+        {
+            if (_replacedFilename != null && File.Exists(_replacedFilename))
+            {
+                File.Delete(_replacedFilename);
+            }
+        }
 
-		private void SetMetaData(TaskItem item, string data, bool set)
-		{
-			if (set)
-			{
-				item.SetMetadata(TemplateFile.MetadataValueTag, data);
-			}
-		}
+        private void SetMetaData(TaskItem item, string data, bool set)
+        {
+            if (set)
+            {
+                item.SetMetadata(TemplateFile.MetadataValueTag, data);
+            }
+        }
 
-		private TaskItem[] GetTaskItems()
-		{
-			return GetTaskItems(true);
-		}
+        private TaskItem[] GetTaskItems()
+        {
+            return GetTaskItems(true);
+        }
 
-		private TaskItem[] GetTaskItems(bool includeMetaData)
-		{
-			List<TaskItem> result = new List<TaskItem>();
-			TaskItem item = new TaskItem("TemplateItem");
-			SetMetaData(item, "**Item1**", includeMetaData);
-			result.Add(item);
-			item = new TaskItem("item2");
-			SetMetaData(item, "**Item2**", includeMetaData);
-			result.Add(item);
-			item = new TaskItem("caseInsensitiveTest");
-			SetMetaData(item, "**Item3**", includeMetaData);
-			result.Add(item);
+        private TaskItem[] GetTaskItems(bool includeMetaData)
+        {
+            List<TaskItem> result = new List<TaskItem>();
+            TaskItem item = new TaskItem("TemplateItem");
+            SetMetaData(item, "**Item1**", includeMetaData);
+            result.Add(item);
+            item = new TaskItem("item2");
+            SetMetaData(item, "**Item2**", includeMetaData);
+            result.Add(item);
+            item = new TaskItem("caseInsensitiveTest");
+            SetMetaData(item, "**Item3**", includeMetaData);
+            result.Add(item);
             item = new TaskItem("Template.Item.With.Dot");
             SetMetaData(item, "**Item4**", includeMetaData);
             result.Add(item);
-			return result.ToArray();
-		}
+            return result.ToArray();
+        }
 
-		private TaskItem[] GetTaskItemsMissing()
-		{
-			List<TaskItem> result = new List<TaskItem>();
-			TaskItem item = new TaskItem("TemplateItem");
-			SetMetaData(item, "**Item1**", true);
-			result.Add(item);
-			item = new TaskItem("caseInsensitiveTest");
-			SetMetaData(item, "**Item3**", true);
-			result.Add(item);
-			return result.ToArray();
-		}
+        private TaskItem[] GetTaskItemsMissing()
+        {
+            List<TaskItem> result = new List<TaskItem>();
+            TaskItem item = new TaskItem("TemplateItem");
+            SetMetaData(item, "**Item1**", true);
+            result.Add(item);
+            item = new TaskItem("caseInsensitiveTest");
+            SetMetaData(item, "**Item3**", true);
+            result.Add(item);
+            return result.ToArray();
+        }
 
-		[Test]
-		public void TemplateFileDefault()
-		{
-			MockBuild build = new MockBuild();
-			TemplateFile tf = new TemplateFile();
-			tf.BuildEngine = build;
-			tf.Template = new TaskItem(_templateFilename);
-			tf.Tokens = GetTaskItems();
-			Assert.IsTrue(tf.Execute());
-			Assert.IsNotNull(tf.OutputFile);
-			Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
-			_replacedFilename = tf.OutputFile.ItemSpec;
-			Assert.AreEqual(Path.ChangeExtension(_templateFilename, ".out"), _replacedFilename);
-			string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
-			Assert.AreEqual(_templateReplaced, replaced);
-		}
+        [Test]
+        public void TemplateFileDefault()
+        {
+            MockBuild build = new MockBuild();
+            TemplateFile tf = new TemplateFile();
+            tf.BuildEngine = build;
+            tf.Template = new TaskItem(_templateFilename);
+            tf.Tokens = GetTaskItems();
+            Assert.IsTrue(tf.Execute());
+            Assert.IsNotNull(tf.OutputFile);
+            Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
+            _replacedFilename = tf.OutputFile.ItemSpec;
+            Assert.AreEqual(Path.ChangeExtension(_templateFilename, ".out"), _replacedFilename);
+            string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
+            Assert.AreEqual(_templateReplaced, replaced);
+        }
 
-		[Test]
-		public void TemplateFileInvalidTemplate()
-		{
-			MockBuild build = new MockBuild();
-			TemplateFile tf = new TemplateFile();
-			tf.BuildEngine = build;
-			tf.Template = new TaskItem("non_existant_file");
-			tf.Tokens = GetTaskItems();
-			Assert.IsFalse(tf.Execute());
-			Assert.AreEqual(1, build.ErrorCount);
-		}
+        [Test]
+        public void TemplateFileInvalidTemplate()
+        {
+            MockBuild build = new MockBuild();
+            TemplateFile tf = new TemplateFile();
+            tf.BuildEngine = build;
+            tf.Template = new TaskItem("non_existant_file");
+            tf.Tokens = GetTaskItems();
+            Assert.IsFalse(tf.Execute());
+            Assert.AreEqual(1, build.ErrorCount);
+        }
 
-		[Test]
-		public void TemplateFileNewFilename()
-		{
-			MockBuild build = new MockBuild();
-			TemplateFile tf = new TemplateFile();
-			tf.BuildEngine = build;
-			tf.Template = new TaskItem(_templateFilename);
-			string outputfile = Path.Combine(Path.GetDirectoryName(_templateFilename), "Replacement.file");
-			tf.OutputFilename = outputfile;
-			tf.Tokens = GetTaskItems();
-			Assert.IsTrue(tf.Execute());
-			Assert.IsNotNull(tf.OutputFile);
-			Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
-			_replacedFilename = tf.OutputFile.ItemSpec;
-			Assert.AreEqual(outputfile, _replacedFilename);
-			string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
-			Assert.AreEqual(_templateReplaced, replaced);
-		}
+        [Test]
+        public void TemplateFileNewFilename()
+        {
+            MockBuild build = new MockBuild();
+            TemplateFile tf = new TemplateFile();
+            tf.BuildEngine = build;
+            tf.Template = new TaskItem(_templateFilename);
+            string outputfile = Path.Combine(Path.GetDirectoryName(_templateFilename), "Replacement.file");
+            tf.OutputFilename = outputfile;
+            tf.Tokens = GetTaskItems();
+            Assert.IsTrue(tf.Execute());
+            Assert.IsNotNull(tf.OutputFile);
+            Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
+            _replacedFilename = tf.OutputFile.ItemSpec;
+            Assert.AreEqual(outputfile, _replacedFilename);
+            string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
+            Assert.AreEqual(_templateReplaced, replaced);
+        }
 
-		[Test]
-		public void TemplateFileNoMetaData()
-		{
-			MockBuild build = new MockBuild();
-			TemplateFile tf = new TemplateFile();
-			tf.BuildEngine = build;
-			tf.Template = new TaskItem(_templateFilename);
-			tf.Tokens = GetTaskItems(false);
-			Assert.IsTrue(tf.Execute());
-			Assert.IsNotNull(tf.OutputFile);
-			Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
-			_replacedFilename = tf.OutputFile.ItemSpec;
-			Assert.AreEqual(Path.ChangeExtension(_templateFilename, ".out"), _replacedFilename);
-			string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
-			string shouldBeReplaced =
-				_template.Replace("${TemplateItem}", "").Replace("${item2}", "").Replace("${CASEInsenSiTiveTest}", "")
+        [Test]
+        public void TemplateFileNoMetaData()
+        {
+            MockBuild build = new MockBuild();
+            TemplateFile tf = new TemplateFile();
+            tf.BuildEngine = build;
+            tf.Template = new TaskItem(_templateFilename);
+            tf.Tokens = GetTaskItems(false);
+            Assert.IsTrue(tf.Execute());
+            Assert.IsNotNull(tf.OutputFile);
+            Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
+            _replacedFilename = tf.OutputFile.ItemSpec;
+            Assert.AreEqual(Path.ChangeExtension(_templateFilename, ".out"), _replacedFilename);
+            string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
+            string shouldBeReplaced =
+                _template.Replace("${TemplateItem}", "").Replace("${item2}", "").Replace("${CASEInsenSiTiveTest}", "")
                     .Replace("${Template.Item.With.Dot}", "");
-			Assert.AreEqual(shouldBeReplaced, replaced);
-		}
+            Assert.AreEqual(shouldBeReplaced, replaced);
+        }
 
-		[Test]
-		public void TemplateFileNoTokens()
-		{
-			MockBuild build = new MockBuild();
-			TemplateFile tf = new TemplateFile();
-			tf.BuildEngine = build;
-			tf.Template = new TaskItem(_templateFilename);
-			Assert.IsTrue(tf.Execute());
-			Assert.IsNotNull(tf.OutputFile);
-			Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
-			_replacedFilename = tf.OutputFile.ItemSpec;
-			Assert.AreEqual(Path.ChangeExtension(_templateFilename, ".out"), _replacedFilename);
-			string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
-			Assert.AreEqual(_template, replaced);
-		}
+        [Test]
+        public void TemplateFileNoTokens()
+        {
+            MockBuild build = new MockBuild();
+            TemplateFile tf = new TemplateFile();
+            tf.BuildEngine = build;
+            tf.Template = new TaskItem(_templateFilename);
+            Assert.IsTrue(tf.Execute());
+            Assert.IsNotNull(tf.OutputFile);
+            Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
+            _replacedFilename = tf.OutputFile.ItemSpec;
+            Assert.AreEqual(Path.ChangeExtension(_templateFilename, ".out"), _replacedFilename);
+            string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
+            Assert.AreEqual(_template, replaced);
+        }
 
-		[Test]
-		public void TemplateFileMissingToken()
-		{
-			MockBuild build = new MockBuild();
-			TemplateFile tf = new TemplateFile();
-			tf.BuildEngine = build;
-			tf.Template = new TaskItem(_templateFilename);
-			tf.Tokens = GetTaskItemsMissing();
-			Assert.IsTrue(tf.Execute());
-			Assert.IsNotNull(tf.OutputFile);
-			Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
-			_replacedFilename = tf.OutputFile.ItemSpec;
-			Assert.AreEqual(Path.ChangeExtension(_templateFilename, ".out"), _replacedFilename);
-			string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
-			string shouldBeReplaced = _template.Replace("${TemplateItem}", "**Item1**").Replace("${CASEInsenSiTiveTest}", "**Item3**");
-			Assert.AreEqual(shouldBeReplaced, replaced);
-		}
-	}
+        [Test]
+        public void TemplateFileMissingToken()
+        {
+            MockBuild build = new MockBuild();
+            TemplateFile tf = new TemplateFile();
+            tf.BuildEngine = build;
+            tf.Template = new TaskItem(_templateFilename);
+            tf.Tokens = GetTaskItemsMissing();
+            Assert.IsTrue(tf.Execute());
+            Assert.IsNotNull(tf.OutputFile);
+            Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
+            _replacedFilename = tf.OutputFile.ItemSpec;
+            Assert.AreEqual(Path.ChangeExtension(_templateFilename, ".out"), _replacedFilename);
+            string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
+            string shouldBeReplaced = _template.Replace("${TemplateItem}", "**Item1**")
+                .Replace("${CASEInsenSiTiveTest}", "**Item3**");
+            Assert.AreEqual(shouldBeReplaced, replaced);
+        }
+
+        [Test]
+        public void TemplateFileReplace()
+        {
+            MockBuild build = new MockBuild();
+            TemplateFile tf = new TemplateFile();
+            tf.BuildEngine = build;
+            tf.Template = new TaskItem(_templateFilename);
+            tf.OutputFilename = _templateFilename;
+            tf.Tokens = GetTaskItems();
+            Assert.IsTrue(tf.Execute());
+            Assert.IsNotNull(tf.OutputFile);
+            Assert.IsTrue(File.Exists(tf.OutputFile.ItemSpec));
+            _replacedFilename = tf.OutputFile.ItemSpec;
+            Assert.AreEqual(_templateFilename, _replacedFilename);
+            string replaced = File.ReadAllText(tf.OutputFile.ItemSpec);
+            Assert.AreEqual(_templateReplaced, replaced);
+        }
+    }
 }

--- a/Source/MSBuild.Community.Tasks/Mail.cs
+++ b/Source/MSBuild.Community.Tasks/Mail.cs
@@ -292,10 +292,11 @@ namespace MSBuild.Community.Tasks
             }
             finally
             {
-	            message?.Dispose();
+                if(message == null)
+                    message.Dispose();
             }
-
-	        return true;
+            
+            return true;
         }
     }
 }

--- a/Source/MSBuild.Community.Tasks/Mail.cs
+++ b/Source/MSBuild.Community.Tasks/Mail.cs
@@ -292,11 +292,10 @@ namespace MSBuild.Community.Tasks
             }
             finally
             {
-                if(message == null)
-                    message.Dispose();
+	            message?.Dispose();
             }
-            
-            return true;
+
+	        return true;
         }
     }
 }

--- a/Source/MSBuild.Community.Tasks/TemplateFile/TemplateFile.cs
+++ b/Source/MSBuild.Community.Tasks/TemplateFile/TemplateFile.cs
@@ -7,149 +7,152 @@ using Microsoft.Build.Utilities;
 
 namespace MSBuild.Community.Tasks
 {
-	/// <summary>
-	/// MSBuild task that replaces tokens in a template file and writes out a new file.
-	/// </summary>
-	/// <example>
-	/// <code><![CDATA[
-	/// <ItemGroup>
-	///		<Tokens Include="Name">
-	///			<ReplacementValue>MSBuild Community Tasks</ReplacementValue>
-	///		</Tokens>
-	/// </ItemGroup>
-	/// 
+    /// <summary>
+    /// MSBuild task that replaces tokens in a template file and writes out a new file.
+    /// </summary>
+    /// <example>
+    /// <code><![CDATA[
+    /// <ItemGroup>
+    ///		<Tokens Include="Name">
+    ///			<ReplacementValue>MSBuild Community Tasks</ReplacementValue>
+    ///		</Tokens>
+    /// </ItemGroup>
+    /// 
     /// <TemplateFile Template="ATemplateFile.template" OutputFilename="ReplacedFile.txt" Tokens="@(Tokens)" />
-	/// ]]></code>
-	/// </example>
-	/// <remarks>Tokens in the template file are formatted using ${var} syntax and names are not 
-	/// case-sensitive, so ${Token} and ${TOKEN} are equivalent.</remarks>
-	public class TemplateFile : Task
-	{
-		/// <summary>
-		/// Meta data tag used for token replacement
-		/// </summary>
-		public static readonly string MetadataValueTag = "ReplacementValue";
-		private ITaskItem _outputFile;
-		private string _outputFilename;
-		private Regex _regex;
-		private ITaskItem _templateFile;
-		private Dictionary<string, string> _tokenPairs;
-		private ITaskItem[] _tokens;
-		private static readonly string DefaultExt = ".out";
-		
-		/// <summary>
-		/// Default constructor. Creates a new TemplateFile task.
-		/// </summary>
-		public TemplateFile()
-		{
-			_regex = new Regex(@"(?<token>\$\{(?<identifier>[^}]*)\})", RegexOptions.Singleline | RegexOptions.Compiled 
-				| RegexOptions.Multiline | RegexOptions.IgnoreCase);
-		}
+    /// ]]></code>
+    /// </example>
+    /// <remarks>Tokens in the template file are formatted using ${var} syntax and names are not 
+    /// case-sensitive, so ${Token} and ${TOKEN} are equivalent.</remarks>
+    public class TemplateFile : Task
+    {
+        /// <summary>
+        /// Meta data tag used for token replacement
+        /// </summary>
+        public static readonly string MetadataValueTag = "ReplacementValue";
+        private ITaskItem _outputFile;
+        private string _outputFilename;
+        private Regex _regex;
+        private ITaskItem _templateFile;
+        private Dictionary<string, string> _tokenPairs;
+        private ITaskItem[] _tokens;
+        private static readonly string DefaultExt = ".out";
 
-		/// <summary>
-		/// The token replaced template file.
-		/// </summary>
-		[Output]
-		public ITaskItem OutputFile
-		{
-			get { return _outputFile; }
-			set { _outputFile = value; }
-		}
+        /// <summary>
+        /// Default constructor. Creates a new TemplateFile task.
+        /// </summary>
+        public TemplateFile()
+        {
+            _regex = new Regex(@"(?<token>\$\{(?<identifier>[^}]*)\})", RegexOptions.Singleline | RegexOptions.Compiled
+                | RegexOptions.Multiline | RegexOptions.IgnoreCase);
+        }
 
-		/// <summary>
-		/// The full path to the output file name.  If no filename is specified (the default) the
-		/// output file will be the Template filename with a .out extension.
-		/// </summary>
-		public string OutputFilename
-		{
-			get { return _outputFilename; }
-			set { _outputFilename = value; }
-		}
+        /// <summary>
+        /// The token replaced template file.
+        /// </summary>
+        [Output]
+        public ITaskItem OutputFile
+        {
+            get { return _outputFile; }
+            set { _outputFile = value; }
+        }
 
-		/// <summary>
-		/// The template file used.  Tokens with values of ${Name} are replaced by name.
-		/// </summary>
-		[Required]
-		public ITaskItem Template
-		{
-			get { return _templateFile; }
-			set { _templateFile = value; }
-		}
+        /// <summary>
+        /// The full path to the output file name.  If no filename is specified (the default) the
+        /// output file will be the Template filename with a .out extension.
+        /// </summary>
+        public string OutputFilename
+        {
+            get { return _outputFilename; }
+            set { _outputFilename = value; }
+        }
 
-		/// <summary>
-		/// List of tokens to replace in the template.  Token name is taken from the TaskItem.ItemSpec and the
-		/// replacement value comes from the ReplacementValue metadata of the item.
-		/// </summary>
-		public ITaskItem[] Tokens
-		{
-			get { return _tokens; }
-			set { _tokens = value; }
-		}
-		
-		/// <summary>
-		/// Executes the task.
-		/// </summary>
-		/// <returns>Success or failure of the task.</returns>
-		public override bool Execute()
-		{
-			bool result = false;
-			if (File.Exists(_templateFile.ItemSpec))
-			{
-				ParseTokens();
-				using (StreamReader reader = new StreamReader(_templateFile.ItemSpec))
-				{
-					string text2 = _regex.Replace(reader.ReadToEnd(), new MatchEvaluator(MatchEval));
-					using (StreamWriter w = new StreamWriter(GetOutputFilename()))
-					{
-						w.Write(text2);
-						w.Flush();
-						Log.LogMessage("Template replaced and written to '{0}'", _outputFilename);
-						result = true;
-					}
-				}
-			}
-			else
-			{
-				Log.LogError("Template File '{0}' cannot be found", _templateFile.ItemSpec);
-			}
-			return result;
-		}
+        /// <summary>
+        /// The template file used.  Tokens with values of ${Name} are replaced by name.
+        /// </summary>
+        [Required]
+        public ITaskItem Template
+        {
+            get { return _templateFile; }
+            set { _templateFile = value; }
+        }
 
-		private string GetOutputFilename()
-		{
-			if (string.IsNullOrEmpty(_outputFilename))
-			{
-				_outputFilename = Path.ChangeExtension(_templateFile.ItemSpec, DefaultExt);
-			}
-			_outputFilename = Path.IsPathRooted(_outputFilename) ? _outputFilename : 
-				Path.Combine(Path.GetDirectoryName(_templateFile.ItemSpec), _outputFilename);
-			_outputFile = new TaskItem(_outputFilename);
-			return _outputFilename;
-		}
+        /// <summary>
+        /// List of tokens to replace in the template.  Token name is taken from the TaskItem.ItemSpec and the
+        /// replacement value comes from the ReplacementValue metadata of the item.
+        /// </summary>
+        public ITaskItem[] Tokens
+        {
+            get { return _tokens; }
+            set { _tokens = value; }
+        }
 
-		private string MatchEval(Match match)
-		{
-			string result = match.Value;
-			if (_tokenPairs.ContainsKey(match.Groups[2].Value))
-			{
-				result = _tokenPairs[match.Groups[2].Value];
-			}
-			return result;
-		}
+        /// <summary>
+        /// Executes the task.
+        /// </summary>
+        /// <returns>Success or failure of the task.</returns>
+        public override bool Execute()
+        {
+            bool result = false;
+            if (File.Exists(_templateFile.ItemSpec))
+            {
+                ParseTokens();
+                string text2;
+                using (StreamReader reader = new StreamReader(_templateFile.ItemSpec))
+                {
+                    text2 = _regex.Replace(reader.ReadToEnd(), new MatchEvaluator(MatchEval));
+                }
 
-		private void ParseTokens()
-		{
-			_tokenPairs = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
-			if (_tokens != null)
-			{
-				foreach (ITaskItem token in _tokens)
-				{
-					if (!String.IsNullOrEmpty(token.ItemSpec))
-					{
-						_tokenPairs.Add(token.ItemSpec, token.GetMetadata(MetadataValueTag));
-					}
-				}
-			}
-		}
-	}
+                using (StreamWriter w = new StreamWriter(GetOutputFilename()))
+                {
+                    w.Write(text2);
+                    w.Flush();
+                    Log.LogMessage("Template replaced and written to '{0}'", _outputFilename);
+                    result = true;
+                }
+
+            }
+            else
+            {
+                Log.LogError("Template File '{0}' cannot be found", _templateFile.ItemSpec);
+            }
+            return result;
+        }
+
+        private string GetOutputFilename()
+        {
+            if (string.IsNullOrEmpty(_outputFilename))
+            {
+                _outputFilename = Path.ChangeExtension(_templateFile.ItemSpec, DefaultExt);
+            }
+            _outputFilename = Path.IsPathRooted(_outputFilename) ? _outputFilename :
+                Path.Combine(Path.GetDirectoryName(_templateFile.ItemSpec), _outputFilename);
+            _outputFile = new TaskItem(_outputFilename);
+            return _outputFilename;
+        }
+
+        private string MatchEval(Match match)
+        {
+            string result = match.Value;
+            if (_tokenPairs.ContainsKey(match.Groups[2].Value))
+            {
+                result = _tokenPairs[match.Groups[2].Value];
+            }
+            return result;
+        }
+
+        private void ParseTokens()
+        {
+            _tokenPairs = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+            if (_tokens != null)
+            {
+                foreach (ITaskItem token in _tokens)
+                {
+                    if (!String.IsNullOrEmpty(token.ItemSpec))
+                    {
+                        _tokenPairs.Add(token.ItemSpec, token.GetMetadata(MetadataValueTag));
+                    }
+                }
+            }
+        }
+    }
 }

--- a/Source/MSBuild.Community.Tasks/TemplateFile/TemplateFile.cs
+++ b/Source/MSBuild.Community.Tasks/TemplateFile/TemplateFile.cs
@@ -7,152 +7,152 @@ using Microsoft.Build.Utilities;
 
 namespace MSBuild.Community.Tasks
 {
-    /// <summary>
-    /// MSBuild task that replaces tokens in a template file and writes out a new file.
-    /// </summary>
-    /// <example>
-    /// <code><![CDATA[
-    /// <ItemGroup>
-    ///		<Tokens Include="Name">
-    ///			<ReplacementValue>MSBuild Community Tasks</ReplacementValue>
-    ///		</Tokens>
-    /// </ItemGroup>
-    /// 
-    /// <TemplateFile Template="ATemplateFile.template" OutputFilename="ReplacedFile.txt" Tokens="@(Tokens)" />
-    /// ]]></code>
-    /// </example>
-    /// <remarks>Tokens in the template file are formatted using ${var} syntax and names are not 
-    /// case-sensitive, so ${Token} and ${TOKEN} are equivalent.</remarks>
-    public class TemplateFile : Task
-    {
-        /// <summary>
-        /// Meta data tag used for token replacement
-        /// </summary>
-        public static readonly string MetadataValueTag = "ReplacementValue";
-        private ITaskItem _outputFile;
-        private string _outputFilename;
-        private Regex _regex;
-        private ITaskItem _templateFile;
-        private Dictionary<string, string> _tokenPairs;
-        private ITaskItem[] _tokens;
-        private static readonly string DefaultExt = ".out";
+	/// <summary>
+	/// MSBuild task that replaces tokens in a template file and writes out a new file.
+	/// </summary>
+	/// <example>
+	/// <code><![CDATA[
+	/// <ItemGroup>
+	///		<Tokens Include="Name">
+	///			<ReplacementValue>MSBuild Community Tasks</ReplacementValue>
+	///		</Tokens>
+	/// </ItemGroup>
+	/// 
+	/// <TemplateFile Template="ATemplateFile.template" OutputFilename="ReplacedFile.txt" Tokens="@(Tokens)" />
+	/// ]]></code>
+	/// </example>
+	/// <remarks>Tokens in the template file are formatted using ${var} syntax and names are not 
+	/// case-sensitive, so ${Token} and ${TOKEN} are equivalent.</remarks>
+	public class TemplateFile : Task
+	{
+		/// <summary>
+		/// Meta data tag used for token replacement
+		/// </summary>
+		public static readonly string MetadataValueTag = "ReplacementValue";
+		private ITaskItem _outputFile;
+		private string _outputFilename;
+		private Regex _regex;
+		private ITaskItem _templateFile;
+		private Dictionary<string, string> _tokenPairs;
+		private ITaskItem[] _tokens;
+		private static readonly string DefaultExt = ".out";
 
-        /// <summary>
-        /// Default constructor. Creates a new TemplateFile task.
-        /// </summary>
-        public TemplateFile()
-        {
-            _regex = new Regex(@"(?<token>\$\{(?<identifier>[^}]*)\})", RegexOptions.Singleline | RegexOptions.Compiled
-                | RegexOptions.Multiline | RegexOptions.IgnoreCase);
-        }
+		/// <summary>
+		/// Default constructor. Creates a new TemplateFile task.
+		/// </summary>
+		public TemplateFile()
+		{
+			_regex = new Regex(@"(?<token>\$\{(?<identifier>[^}]*)\})", RegexOptions.Singleline | RegexOptions.Compiled
+				| RegexOptions.Multiline | RegexOptions.IgnoreCase);
+		}
 
-        /// <summary>
-        /// The token replaced template file.
-        /// </summary>
-        [Output]
-        public ITaskItem OutputFile
-        {
-            get { return _outputFile; }
-            set { _outputFile = value; }
-        }
+		/// <summary>
+		/// The token replaced template file.
+		/// </summary>
+		[Output]
+		public ITaskItem OutputFile
+		{
+			get { return _outputFile; }
+			set { _outputFile = value; }
+		}
 
-        /// <summary>
-        /// The full path to the output file name.  If no filename is specified (the default) the
-        /// output file will be the Template filename with a .out extension.
-        /// </summary>
-        public string OutputFilename
-        {
-            get { return _outputFilename; }
-            set { _outputFilename = value; }
-        }
+		/// <summary>
+		/// The full path to the output file name.  If no filename is specified (the default) the
+		/// output file will be the Template filename with a .out extension.
+		/// </summary>
+		public string OutputFilename
+		{
+			get { return _outputFilename; }
+			set { _outputFilename = value; }
+		}
 
-        /// <summary>
-        /// The template file used.  Tokens with values of ${Name} are replaced by name.
-        /// </summary>
-        [Required]
-        public ITaskItem Template
-        {
-            get { return _templateFile; }
-            set { _templateFile = value; }
-        }
+		/// <summary>
+		/// The template file used.  Tokens with values of ${Name} are replaced by name.
+		/// </summary>
+		[Required]
+		public ITaskItem Template
+		{
+			get { return _templateFile; }
+			set { _templateFile = value; }
+		}
 
-        /// <summary>
-        /// List of tokens to replace in the template.  Token name is taken from the TaskItem.ItemSpec and the
-        /// replacement value comes from the ReplacementValue metadata of the item.
-        /// </summary>
-        public ITaskItem[] Tokens
-        {
-            get { return _tokens; }
-            set { _tokens = value; }
-        }
+		/// <summary>
+		/// List of tokens to replace in the template.  Token name is taken from the TaskItem.ItemSpec and the
+		/// replacement value comes from the ReplacementValue metadata of the item.
+		/// </summary>
+		public ITaskItem[] Tokens
+		{
+			get { return _tokens; }
+			set { _tokens = value; }
+		}
 
-        /// <summary>
-        /// Executes the task.
-        /// </summary>
-        /// <returns>Success or failure of the task.</returns>
-        public override bool Execute()
-        {
-            bool result = false;
-            if (File.Exists(_templateFile.ItemSpec))
-            {
-                ParseTokens();
-                string text2;
-                using (StreamReader reader = new StreamReader(_templateFile.ItemSpec))
-                {
-                    text2 = _regex.Replace(reader.ReadToEnd(), new MatchEvaluator(MatchEval));
-                }
+		/// <summary>
+		/// Executes the task.
+		/// </summary>
+		/// <returns>Success or failure of the task.</returns>
+		public override bool Execute()
+		{
+			bool result = false;
+			if (File.Exists(_templateFile.ItemSpec))
+			{
+				ParseTokens();
+				string text2;
+				using (StreamReader reader = new StreamReader(_templateFile.ItemSpec))
+				{
+					text2 = _regex.Replace(reader.ReadToEnd(), new MatchEvaluator(MatchEval));
+				}
 
-                using (StreamWriter w = new StreamWriter(GetOutputFilename()))
-                {
-                    w.Write(text2);
-                    w.Flush();
-                    Log.LogMessage("Template replaced and written to '{0}'", _outputFilename);
-                    result = true;
-                }
+				using (StreamWriter w = new StreamWriter(GetOutputFilename()))
+				{
+					w.Write(text2);
+					w.Flush();
+					Log.LogMessage("Template replaced and written to '{0}'", _outputFilename);
+					result = true;
+				}
 
-            }
-            else
-            {
-                Log.LogError("Template File '{0}' cannot be found", _templateFile.ItemSpec);
-            }
-            return result;
-        }
+			}
+			else
+			{
+				Log.LogError("Template File '{0}' cannot be found", _templateFile.ItemSpec);
+			}
+			return result;
+		}
 
-        private string GetOutputFilename()
-        {
-            if (string.IsNullOrEmpty(_outputFilename))
-            {
-                _outputFilename = Path.ChangeExtension(_templateFile.ItemSpec, DefaultExt);
-            }
-            _outputFilename = Path.IsPathRooted(_outputFilename) ? _outputFilename :
-                Path.Combine(Path.GetDirectoryName(_templateFile.ItemSpec), _outputFilename);
-            _outputFile = new TaskItem(_outputFilename);
-            return _outputFilename;
-        }
+		private string GetOutputFilename()
+		{
+			if (string.IsNullOrEmpty(_outputFilename))
+			{
+				_outputFilename = Path.ChangeExtension(_templateFile.ItemSpec, DefaultExt);
+			}
+			_outputFilename = Path.IsPathRooted(_outputFilename) ? _outputFilename :
+				Path.Combine(Path.GetDirectoryName(_templateFile.ItemSpec), _outputFilename);
+			_outputFile = new TaskItem(_outputFilename);
+			return _outputFilename;
+		}
 
-        private string MatchEval(Match match)
-        {
-            string result = match.Value;
-            if (_tokenPairs.ContainsKey(match.Groups[2].Value))
-            {
-                result = _tokenPairs[match.Groups[2].Value];
-            }
-            return result;
-        }
+		private string MatchEval(Match match)
+		{
+			string result = match.Value;
+			if (_tokenPairs.ContainsKey(match.Groups[2].Value))
+			{
+				result = _tokenPairs[match.Groups[2].Value];
+			}
+			return result;
+		}
 
-        private void ParseTokens()
-        {
-            _tokenPairs = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
-            if (_tokens != null)
-            {
-                foreach (ITaskItem token in _tokens)
-                {
-                    if (!String.IsNullOrEmpty(token.ItemSpec))
-                    {
-                        _tokenPairs.Add(token.ItemSpec, token.GetMetadata(MetadataValueTag));
-                    }
-                }
-            }
-        }
-    }
+		private void ParseTokens()
+		{
+			_tokenPairs = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+			if (_tokens != null)
+			{
+				foreach (ITaskItem token in _tokens)
+				{
+					if (!String.IsNullOrEmpty(token.ItemSpec))
+					{
+						_tokenPairs.Add(token.ItemSpec, token.GetMetadata(MetadataValueTag));
+					}
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
if you set OutputFilename the same as Template, you'll get an error: File used by another process.
So, sometimes it's usefull to replace template file and do not create a new one.

So, I close StreamReader before writing to file.