### PR TITLE
Fixed issues when using relative paths in task definition

### DIFF
--- a/Source/MSBuild.Community.Tasks/Zip.cs
+++ b/Source/MSBuild.Community.Tasks/Zip.cs
@@ -254,7 +254,7 @@ namespace MSBuild.Community.Tasks
                         if (Flatten)
                             directoryPathInArchive = string.Empty;
                         else if (!string.IsNullOrEmpty(WorkingDirectory))
-                            directoryPathInArchive = GetPath(name, WorkingDirectory);
+                            directoryPathInArchive = GetPath(name, Path.GetFullPath(WorkingDirectory));
                         else
                             directoryPathInArchive = null;
 


### PR DESCRIPTION
Files are handled by using the absolute path (since 9ea598cdc230e6c1ccd76ea5574bdce01a8bfb9d) so directories should also be handled by using the full absolute path.
Otherwise the path inside of the zip file is wrong.