### PR TITLE
Removed mismatched paren

### DIFF
--- a/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Targets
+++ b/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Targets
@@ -5,7 +5,7 @@
     <MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == '' and '$(MSBuildThisFile)' == 'MSBuild.Community.Tasks.Targets'">$(MSBuildThisFileDirectory)</MSBuildCommunityTasksPath>
     <MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == '' and '$(MSBuildThisFile)' == 'MSBuildTasks.targets'">$(MSBuildThisFileDirectory)\..\tools</MSBuildCommunityTasksPath>
     <MSBuildCommunityTasksLib Condition="'$(OS)' == 'Windows_NT'">$([MSBUILD]::Unescape($(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.dll))</MSBuildCommunityTasksLib>
-    <MSBuildCommunityTasksLib Condition="'$(OS)' != 'Windows_NT'">$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.dll)</MSBuildCommunityTasksLib>
+    <MSBuildCommunityTasksLib Condition="'$(OS)' != 'Windows_NT'">$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.dll</MSBuildCommunityTasksLib>
     <MSBuildCommunityTasksLib Condition="!Exists('$(MSBuildCommunityTasksLib)')">MSBuild.Community.Tasks.dll</MSBuildCommunityTasksLib>
   </PropertyGroup>
 


### PR DESCRIPTION
Removed mismatched paren in non windows MSBuildCommunityTasksLib variable. This caused task lookup errors in a Xamarin build.

Our use of the 'time' task failed, and was looking in the default location in the 'build' folder (next to the .targets file) for the library DLL, instead of the correct relative location under 'tools'. The extra paren makes the next line 'exists' check fail, and replaces the path with the incorrect default path. Without the paren the library path is correct, and our build now works.