### PR TITLE
Update DotNetZip to prevent corrupt zip archives

### DIFF
--- a/Master.proj
+++ b/Master.proj
@@ -91,7 +91,7 @@
     <!-- Merge together files -->
     <ItemGroup>
       <InputAssemblies Include="$(BuildFolder)\MSBuild.Temp.dll" />
-      <InputAssemblies Include="$(BuildFolder)\Ionic.Zip.Reduced.dll" />
+      <InputAssemblies Include="$(BuildFolder)\DotNetZip.dll" />
     </ItemGroup>
     
     <ILRepack Internalize="true"

--- a/Source/MSBuild.Community.Tasks.Tests/MSBuild.Community.Tasks.Tests.csproj
+++ b/Source/MSBuild.Community.Tasks.Tests/MSBuild.Community.Tasks.Tests.csproj
@@ -37,8 +37,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Ionic.Zip.Reduced, Version=1.9.1.8, Culture=neutral, PublicKeyToken=edbe51ad942a3f5c, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetZip.Reduced.1.9.1.8\lib\net20\Ionic.Zip.Reduced.dll</HintPath>
+    <Reference Include="DotNetZip, Version=1.10.1.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetZip.1.10.1\lib\net20\DotNetZip.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Tasks.v4.0" />

--- a/Source/MSBuild.Community.Tasks.Tests/MSBuild.Community.Tasks.Tests.csproj
+++ b/Source/MSBuild.Community.Tasks.Tests/MSBuild.Community.Tasks.Tests.csproj
@@ -39,7 +39,6 @@
   <ItemGroup>
     <Reference Include="DotNetZip, Version=1.10.1.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
       <HintPath>..\packages\DotNetZip.1.10.1\lib\net20\DotNetZip.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Tasks.v4.0" />

--- a/Source/MSBuild.Community.Tasks.Tests/ZipTest.cs
+++ b/Source/MSBuild.Community.Tasks.Tests/ZipTest.cs
@@ -21,7 +21,7 @@ namespace MSBuild.Community.Tasks.Tests
         public const string ZIP_WITH_RELATIVE_FILE_NAME = @"MSBuild.Community.Tasks.WithReltive.zip";
 	    public const string ZIP_128KB_FILE_NAME = @"MSBuild.Community.Tasks.128KB.zip";
 
-		[Test(Description = "Zip files into a zip archive")]
+        [Test(Description = "Zip files into a zip archive")]
         public void ZipExecute()
         {
             var task = new Zip();

--- a/Source/MSBuild.Community.Tasks.Tests/ZipTest.cs
+++ b/Source/MSBuild.Community.Tasks.Tests/ZipTest.cs
@@ -138,30 +138,29 @@ namespace MSBuild.Community.Tasks.Tests
             task.BuildEngine = new MockBuild();
 
             string testDir = TaskUtility.TestDirectory;
-            string prjRootPath = TaskUtility.GetProjectRootDirectory(true);
-            string workingDir = Path.Combine(prjRootPath, @"Source\MSBuild.Community.Tasks.Tests");
 
             string testFile = Path.Combine(testDir, "zip-128kb-test-1.dat");
             const int numberOfBytes = 1024*128*9;
+            if (File.Exists(testFile)) File.Delete(testFile);
             CreateTestFile(numberOfBytes, testFile);
 
             task.Files = new[] {new TaskItem(testFile)};
-            task.WorkingDirectory = workingDir;
+            task.WorkingDirectory = testDir;
             task.ParallelCompression = true;
             task.ZipFileName = Path.Combine(testDir, ZIP_128KB_FILE_NAME);
 
             if (File.Exists(task.ZipFileName)) File.Delete(task.ZipFileName);
 
             // First zip up the file
-            bool result = task.Execute();
-            Assert.IsTrue(result, "Execute Failed");
+            Assert.IsTrue(task.Execute(), "Execute Failed");
             Assert.IsTrue(File.Exists(task.ZipFileName), "Zip file not found");
 
-            // Then try to unzip the file
+            // Then delete the original, and try to unzip the file
+            File.Delete(testFile);
             Unzip unzipTask = new Unzip();
             unzipTask.BuildEngine = new MockBuild();
             unzipTask.ZipFileName = task.ZipFileName;
-            unzipTask.TargetDirectory = Path.Combine(testDir);
+            unzipTask.TargetDirectory = testDir;
             Assert.IsTrue(unzipTask.Execute());
         }
 

--- a/Source/MSBuild.Community.Tasks.Tests/packages.config
+++ b/Source/MSBuild.Community.Tasks.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetZip.Reduced" version="1.9.1.8" />
+  <package id="DotNetZip" version="1.10.1" targetFramework="net40" />
   <package id="NUnit" version="3.2.1" targetFramework="net40" />
   <package id="RhinoMocks" version="3.6.1" />
 </packages>

--- a/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.csproj
+++ b/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.csproj
@@ -42,8 +42,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Ionic.Zip.Reduced, Version=1.9.1.8, Culture=neutral, PublicKeyToken=edbe51ad942a3f5c, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetZip.Reduced.1.9.1.8\lib\net20\Ionic.Zip.Reduced.dll</HintPath>
+    <Reference Include="DotNetZip, Version=1.10.1.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetZip.1.10.1\lib\net20\DotNetZip.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />

--- a/Source/MSBuild.Community.Tasks/packages.config
+++ b/Source/MSBuild.Community.Tasks/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetZip.Reduced" version="1.9.1.8" />
+  <package id="DotNetZip" version="1.10.1" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
DotNetZip.Reduced.1.9.1.8 was last updated in 2012. The fork DotNetZip.Semverd is better maintained and fixes an [issue](https://dotnetzip.codeplex.com/workitem/14087) with zipping files which are a multiple of 128KB, which causes [problems](https://github.com/loresoft/msbuildtasks/issues/2) when using ParallelCompression in the Zip task.