### PR TITLE
[script] Ignore warnings

### DIFF
--- a/Source/MSBuild.Community.Tasks/Script.cs
+++ b/Source/MSBuild.Community.Tasks/Script.cs
@@ -219,7 +219,7 @@ namespace MSBuild.Community.Tasks
 			CompilerResults results = provider.CompileAssemblyFromDom(options, compileUnit);
 
 			Assembly compiled = null;
-			if (results.Errors.Count > 0)
+			if (results.Errors.HasErrors)
 			{
 				string errors = "There were compiler errors:" + Environment.NewLine;
 				foreach (CompilerError err in results.Errors)


### PR DESCRIPTION
Don't fail the script task if compilation produces warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/loresoft/msbuildtasks/246)
<!-- Reviewable:end -->
