### PR TITLE
New property "ForceEnglishOutput" in NuGetPack.

### DIFF
--- a/Source/MSBuild.Community.Tasks/NuGet/NuGetPack.cs
+++ b/Source/MSBuild.Community.Tasks/NuGet/NuGetPack.cs
@@ -162,6 +162,14 @@ namespace MSBuild.Community.Tasks.NuGet
         public string MinClientVersion { get; set; }
 
         /// <summary>
+        /// (v3.5) Forces NuGet to run using an invariant, English-based culture.
+        /// </summary>
+        /// <remarks>
+        /// Only available starting in version 3.5.
+        /// </remarks>
+        public bool ForceEnglishOutput { get; set; }
+
+        /// <summary>
         /// The full file path of the NuGet package created by the NuGetPack task
         /// </summary>
         [Output]
@@ -209,6 +217,9 @@ namespace MSBuild.Community.Tasks.NuGet
 
             if (IncludeReferencedProjects)
                 builder.AppendSwitch("-IncludeReferencedProjects");
+
+            if (ForceEnglishOutput)
+                builder.AppendSwitch("-ForceEnglishOutput");
 
             builder.AppendSwitchIfNotNull("-Exclude", Exclude);
             builder.AppendSwitchIfNotNull("-Properties ", Properties);


### PR DESCRIPTION
This option was added with NuGet 3.5 and outputs all messages in english. This way the property "OutputFilePath" will get populated on non-english systems.