### PR TITLE
Show more details on Xslt failures.

### DIFF
--- a/Source/MSBuild.Community.Tasks/Xslt/Xslt.cs
+++ b/Source/MSBuild.Community.Tasks/Xslt/Xslt.cs
@@ -275,7 +275,7 @@ namespace MSBuild.Community.Tasks
 			}
 			catch (XsltException ex)
 			{
-				Log.LogErrorFromException(ex);
+				Log.LogErrorFromException(ex, false, true, new Uri(ex.SourceUri).LocalPath + '(' + ex.LineNumber + ',' + ex.LinePosition + ')');
 				return false;
 			}
 			catch (FileNotFoundException ex)
@@ -290,7 +290,7 @@ namespace MSBuild.Community.Tasks
 			}
 			catch (XmlException ex)
 			{
-				Log.LogErrorFromException(ex);
+				Log.LogErrorFromException(ex, false, true, new Uri(ex.SourceUri).LocalPath + '(' + ex.LineNumber + ',' + ex.LinePosition + ')');
 				return false;
 			}
 			finally


### PR DESCRIPTION
If something goes wrong with the `Xslt` task, MSBuild only shows `XSLT error`, and it's possible to navigate to the line where MSBuild invokes the Xslt task.
There is no help given about which line failed, and why.

This PR logs more information from the exceptions, even enabling jumping to the failing line immediately in the IDE. Since key information is often buried here in the inner exceptions, log those messages, too.