### PR TITLE
Removed extra slash

### DIFF
--- a/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Targets
+++ b/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Targets
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == '' and '$(MSBuildThisFile)' == 'MSBuild.Community.Tasks.Targets'">$(MSBuildThisFileDirectory)</MSBuildCommunityTasksPath>
-    <MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == '' and '$(MSBuildThisFile)' == 'MSBuildTasks.targets'">$(MSBuildThisFileDirectory)\..\tools</MSBuildCommunityTasksPath>
+    <MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == '' and '$(MSBuildThisFile)' == 'MSBuildTasks.targets'">$(MSBuildThisFileDirectory)..\tools</MSBuildCommunityTasksPath>
     <MSBuildCommunityTasksLib Condition="'$(OS)' == 'Windows_NT'">$([MSBUILD]::Unescape($(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.dll))</MSBuildCommunityTasksLib>
     <MSBuildCommunityTasksLib Condition="'$(OS)' != 'Windows_NT'">$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.dll</MSBuildCommunityTasksLib>
     <MSBuildCommunityTasksLib Condition="!Exists('$(MSBuildCommunityTasksLib)')">MSBuild.Community.Tasks.dll</MSBuildCommunityTasksLib>


### PR DESCRIPTION
`MSBuildThisFileDirectory` already contains a trailing slash, and on case-sensitive file systems, writing the path as `\\..\tools\` has caused issues for me; it wouldn't manage to load the MSBuildTasks assembly properly.

(Moving the project to a case-insensitive file system fixed it for me. I tried opening the path in Windows Explorer which had similar issues, so I _think_ this would be the right and obvious fix to it.)