### PR TITLE
improve: TemplateFile: allow to define input and output file encodings

### DIFF
--- a/Documentation/TaskDocs.md
+++ b/Documentation/TaskDocs.md
@@ -2505,7 +2505,7 @@ MSBuild task that replaces tokens in a template file and writes out a new file.
             	</Tokens>
       </ItemGroup>
             
-      <TemplateFile Template="ATemplateFile.template" OutputFilename="ReplacedFile.txt" Tokens="@(Tokens)" />
+      <TemplateFile Template="ATemplateFile.template" TemplateEncoding="Windows-1251" OutputFilename="ReplacedFile.txt" OutputEncoding="UTF-16" Tokens="@(Tokens)" />
             
             
 * * *


### PR DESCRIPTION
The input files are not always in UTF-8 encoding as it is assumed by
default. Let user to define an actual encoding. Also, let user to
redefine an output file encoding (but usually it is the same as an input
template).