### PR TITLE
MSBuildCommunityTasksPath: Fix build failure

### DIFF
--- a/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Targets
+++ b/Source/MSBuild.Community.Tasks/MSBuild.Community.Tasks.Targets
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == '' and '$(MSBuildThisFile)' == 'MSBuild.Community.Tasks.Targets'">$(MSBuildThisFileDirectory)</MSBuildCommunityTasksPath>
-    <MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == '' and '$(MSBuildThisFile)' == 'MSBuildTasks.targets'">$(MSBuildThisFileDirectory)\..\tools</MSBuildCommunityTasksPath>
+    <MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == '' and '$(MSBuildThisFile)' == 'MSBuildTasks.targets'">$(MSBuildThisFileDirectory)..\tools</MSBuildCommunityTasksPath>
     <MSBuildCommunityTasksLib Condition="'$(OS)' == 'Windows_NT'">$([MSBUILD]::Unescape($(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.dll))</MSBuildCommunityTasksLib>
     <MSBuildCommunityTasksLib Condition="'$(OS)' != 'Windows_NT'">$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.dll</MSBuildCommunityTasksLib>
     <MSBuildCommunityTasksLib Condition="!Exists('$(MSBuildCommunityTasksLib)')">MSBuild.Community.Tasks.dll</MSBuildCommunityTasksLib>


### PR DESCRIPTION
Without this change, I get build errors when trying to use the MSBuild Community Tasks:

> \\Mac\Home\git-case-insensitive\acmeinc\acmeinc.productstructureeditor\src\Shells\ProductStructureEditorFeature10.0.1\ProductStructureEditorFeature10.0.1.csproj(238,5): error MSB4062: The "MSBuild.Community.Tasks.Xml.XmlQuery" task could not be loaded from the assembly \\Mac\Home\git-case-insensitive\acmeinc\acmeinc.productstructureeditor\src\packages\MSBuildTasks.1.5.0.235\build\\\\..\tools\MSBuild.Community.Tasks.dll. Could not load file or assembly 'file://\\Mac\Home\git-case-insensitive\acmeinc\acmeinc.productstructureeditor\src\packages\MSBuildTasks.1.5.0.235\build\\\\..\tools\MSBuild.Community.Tasks.dll' or one of its dependencies. The system cannot find the file specified. Confirm that the <UsingTask> declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.

Please note that the path contains `\\`, which is likely to cause the problem. `MSBuildThisFileDirectory` already contains a trailing slash, at least in my scenario.

Applying this change in the `.targets` file in my local NuGet packages folder makes the build succeed. My workstation is a Parallels VM running on macOS, with a Windows 7 VM running Visual Studio 2017.