### PR TITLE
Prevent null/white space task item from being created.

### DIFF
--- a/Source/MSBuild.Community.Tasks/Git/GitClient.cs
+++ b/Source/MSBuild.Community.Tasks/Git/GitClient.cs
@@ -218,10 +218,13 @@ namespace MSBuild.Community.Tasks.Git
         /// <param name="messageImportance">A value of <see cref="T:Microsoft.Build.Framework.MessageImportance"/> that indicates the importance level with which to log the message.</param>
         protected override void LogEventsFromTextOutput(string singleLine, MessageImportance messageImportance)
         {
-                base.LogEventsFromTextOutput(singleLine, messageImportance);
+            base.LogEventsFromTextOutput(singleLine, messageImportance);
 
-            var messageItem = new TaskItem(singleLine);
-            _consoleOut.Add(messageItem);
+            if (!string.IsNullOrWhiteSpace(singleLine))
+            {
+                var messageItem = new TaskItem(singleLine);
+                _consoleOut.Add(messageItem);
+            }
         }
 
     }


### PR DESCRIPTION
Ref: https://github.com/Microsoft/msbuild/issues/3399

error MSB4028: The "MSBuild.Community.Tasks.Git.GitClient" task's outputs could not be retrieved from the "ConsoleOutput" parameter. Parameter "includeEscaped" cannot have zero length.

`		<MSBuild.Community.Tasks.Git.GitClient Command="push" Arguments="origin" UseCommandProcessor="false" LocalPath="$(DestinationFolder)\" Condition="Exists('$(DestinationFolder)\.git')" ContinueOnError="true">
			<Output TaskParameter="ConsoleOutput" ItemName="ConsoleOutputPush"/>
		</MSBuild.Community.Tasks.Git.GitClient>`